### PR TITLE
Setting the default LINK_TARGETS to none

### DIFF
--- a/sky130/Makefile
+++ b/sky130/Makefile
@@ -72,9 +72,8 @@ STAGING_PATH = `pwd`
 # from source, where they don't.
 
 # LINK_TARGETS = source
-# LINK_TARGETS = none
+LINK_TARGETS = none
 # LINK_TARGETS = sky130A
-LINK_TARGETS = source
 
 # Paths:
 


### PR DESCRIPTION
- The installation can run in docker containers by default of course at the cost
  of disk space.