### PR TITLE
Continuation operator needed in sky130/Makefile.in

### DIFF
--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -428,10 +428,10 @@ vendor-a:
 	# 	"FIXED_BBOX 0 407 15000 40000"
 
 install:
-	if test "x${DIST_PATH}" == "x" ; then
-	    ${MAKE} install-local
-	else
-	    ${MAKE} install-dist
+	if test "x${DIST_PATH}" == "x" ; then \
+	    ${MAKE} install-local ; \
+	else \
+	    ${MAKE} install-dist; \
 	fi
 
 install-local: install-local-a


### PR DESCRIPTION
Every line is run in a new shell by make, so need a continuation operator there.