### PR TITLE
openlane configs updates

### DIFF
--- a/sky130/openlane/common_pdn.tcl
+++ b/sky130/openlane/common_pdn.tcl
@@ -7,7 +7,7 @@ set ::macro_blockage_layer_list "li1 met1 met2 met3 met4 met5"
 pdngen::specify_grid stdcell {
     name grid
     rails {
-	    met1 {width 0.48 pitch $::env(PLACE_SITE_HEIGHT) offset 0}
+	    met1 {width $::env(PDN_RAIL_WIDTH) pitch $::env(PLACE_SITE_HEIGHT) offset 0}
     }
     straps {
 	    met4 {width 1.6 pitch $::env(FP_PDN_VPITCH) offset $::env(FP_PDN_VOFFSET)}

--- a/sky130/openlane/common_pdn.tcl
+++ b/sky130/openlane/common_pdn.tcl
@@ -7,11 +7,11 @@ set ::macro_blockage_layer_list "li1 met1 met2 met3 met4 met5"
 pdngen::specify_grid stdcell {
     name grid
     rails {
-	    met1 {width $::env(PDN_RAIL_WIDTH) pitch $::env(PLACE_SITE_HEIGHT) offset 0}
+	    met1 {width $::env(PDN_RAIL_WIDTH) pitch $::env(PLACE_SITE_HEIGHT) offset $::env(PDN_RAIL_OFFSET)}
     }
     straps {
-	    met4 {width 1.6 pitch $::env(FP_PDN_VPITCH) offset $::env(FP_PDN_VOFFSET)}
-	    met5 {width 1.6 pitch $::env(FP_PDN_HPITCH) offset $::env(FP_PDN_HOFFSET)}
+	    met4 {width $::env(PDN_STRAP_VWIDTH) pitch $::env(FP_PDN_VPITCH) offset $::env(FP_PDN_VOFFSET)}
+	    met5 {width $::env(PDN_STRAP_HWIDTH) pitch $::env(FP_PDN_HPITCH) offset $::env(FP_PDN_HOFFSET)}
     }
     connect {{met1 met4} {met4 met5}}
 }

--- a/sky130/openlane/common_pdn.tcl
+++ b/sky130/openlane/common_pdn.tcl
@@ -7,11 +7,11 @@ set ::macro_blockage_layer_list "li1 met1 met2 met3 met4 met5"
 pdngen::specify_grid stdcell {
     name grid
     rails {
-	    met1 {width $::env(PDN_RAIL_WIDTH) pitch $::env(PLACE_SITE_HEIGHT) offset $::env(PDN_RAIL_OFFSET)}
+	    met1 {width $::env(FP_PDN_RAIL_WIDTH) pitch $::env(PLACE_SITE_HEIGHT) offset $::env(FP_PDN_RAIL_OFFSET)}
     }
     straps {
-	    met4 {width $::env(PDN_STRAP_VWIDTH) pitch $::env(FP_PDN_VPITCH) offset $::env(FP_PDN_VOFFSET)}
-	    met5 {width $::env(PDN_STRAP_HWIDTH) pitch $::env(FP_PDN_HPITCH) offset $::env(FP_PDN_HOFFSET)}
+	    met4 {width $::env(FP_PDN_VWIDTH) pitch $::env(FP_PDN_VPITCH) offset $::env(FP_PDN_VOFFSET)}
+	    met5 {width $::env(FP_PDN_HWIDTH) pitch $::env(FP_PDN_HPITCH) offset $::env(FP_PDN_HOFFSET)}
     }
     connect {{met1 met4} {met4 met5}}
 }

--- a/sky130/openlane/config.tcl
+++ b/sky130/openlane/config.tcl
@@ -33,6 +33,8 @@ set ::env(NETGEN_SETUP_FILE) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/netgen/TECH
 # CTS luts
 set ::env(CTS_TECH_DIR) "N/A"
 
+set ::env(CTS_SQR_CAP) 0.258e-3
+set ::env(CTS_SQR_RES) 0.125
 set ::env(FP_TAPCELL_DIST) 14
 
 # Tracks info

--- a/sky130/openlane/config.tcl
+++ b/sky130/openlane/config.tcl
@@ -43,6 +43,6 @@ set ::env(TRACKS_INFO_FILE) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::
 set ::env(GLB_RT_L1_ADJUSTMENT) 0.99
 
 # Extra PDN configs
-set ::env(PDN_RAIL_OFFSET) 0
-set ::env(PDN_STRAP_VWIDTH) 1.6
-set ::env(PDN_STRAP_HWIDTH) 1.6
+set ::env(FP_PDN_RAIL_OFFSET) 0
+set ::env(FP_PDN_VWIDTH) 1.6
+set ::env(FP_PDN_HWIDTH) 1.6

--- a/sky130/openlane/config.tcl
+++ b/sky130/openlane/config.tcl
@@ -41,3 +41,8 @@ set ::env(FP_TAPCELL_DIST) 14
 set ::env(TRACKS_INFO_FILE) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/tracks.info"
 
 set ::env(GLB_RT_L1_ADJUSTMENT) 0.99
+
+# Extra PDN configs
+set ::env(PDN_RAIL_OFFSET) 0
+set ::env(PDN_STRAP_VWIDTH) 1.6
+set ::env(PDN_STRAP_HWIDTH) 1.6

--- a/sky130/openlane/sky130_fd_sc_hd/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hd/config.tcl
@@ -63,3 +63,5 @@ set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hd__clkbuf_1 sky130_fd_sc_hd__clkbu
 set ::env(CTS_SQR_CAP) 0.258e-3
 set ::env(CTS_SQR_RES) 0.125
 set ::env(CTS_MAX_CAP) 1.53169
+
+set ::env(PDN_RAIL_WIDTH) 0.48

--- a/sky130/openlane/sky130_fd_sc_hd/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hd/config.tcl
@@ -64,4 +64,4 @@ set ::env(CTS_SQR_CAP) 0.258e-3
 set ::env(CTS_SQR_RES) 0.125
 set ::env(CTS_MAX_CAP) 1.53169
 
-set ::env(PDN_RAIL_WIDTH) 0.48
+set ::env(FP_PDN_RAIL_WIDTH) 0.48

--- a/sky130/openlane/sky130_fd_sc_hdll/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hdll/config.tcl
@@ -66,4 +66,4 @@ set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hdll__clkbuf_1 sky130_fd_sc_hdll__c
 set ::env(CTS_SQR_CAP) 0.258e-3
 set ::env(CTS_SQR_RES) 0.125
 set ::env(CTS_MAX_CAP) 1.53169
-set ::env(PDN_RAIL_WIDTH) 0.48
+set ::env(FP_PDN_RAIL_WIDTH) 0.48

--- a/sky130/openlane/sky130_fd_sc_hdll/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hdll/config.tcl
@@ -66,3 +66,4 @@ set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hdll__clkbuf_1 sky130_fd_sc_hdll__c
 set ::env(CTS_SQR_CAP) 0.258e-3
 set ::env(CTS_SQR_RES) 0.125
 set ::env(CTS_MAX_CAP) 1.53169
+set ::env(PDN_RAIL_WIDTH) 0.48

--- a/sky130/openlane/sky130_fd_sc_hs/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hs/config.tcl
@@ -63,4 +63,4 @@ set ::env(CTS_SQR_CAP) 0.469e-3
 set ::env(CTS_SQR_RES) 0.125
 set ::env(CTS_MAX_CAP) 1.8894300000
 
-set ::env(PDN_RAIL_WIDTH) 0.48
+set ::env(FP_PDN_RAIL_WIDTH) 0.48

--- a/sky130/openlane/sky130_fd_sc_hs/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hs/config.tcl
@@ -62,3 +62,5 @@ set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hs__clkbuf_2 sky130_fd_sc_hs__clkbu
 set ::env(CTS_SQR_CAP) 0.469e-3
 set ::env(CTS_SQR_RES) 0.125
 set ::env(CTS_MAX_CAP) 1.8894300000
+
+set ::env(PDN_RAIL_WIDTH) 0.48

--- a/sky130/openlane/sky130_fd_sc_hvl/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hvl/config.tcl
@@ -66,4 +66,4 @@ set ::env(CLK_BUFFER_OUTPUT) X
 set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hvl__buf_1 sky130_fd_sc_hvl__buf_2 sky130_fd_sc_hvl__buf_4 sky130_fd_sc_hvl__buf_8"
 set ::env(CTS_MAX_CAP) 5.57100
 
-set ::env(PDN_RAIL_WIDTH) 0.51
+set ::env(FP_PDN_RAIL_WIDTH) 0.51

--- a/sky130/openlane/sky130_fd_sc_hvl/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hvl/config.tcl
@@ -28,18 +28,18 @@ set ::env(PLACE_SITE_HEIGHT) 4.070
 set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_hvl__decap_4"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hvl_inv_16"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hvl__inv_16"
 #capacitance : 0.017653;
 set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
 # update these
-set ::env(SYNTH_CAP_LOAD) "70.77" ; # femtofarad __inv_8 pin A cap
+set ::env(SYNTH_CAP_LOAD) "35.49" ; # femtofarad __inv_8 pin A cap
 set ::env(SYNTH_MIN_BUF_PORT) "sky130_fd_sc_hvl__buf_1 A X"
 set ::env(SYNTH_TIEHI_PORT) "sky130_fd_sc_hvl__conb_1 HI"
 set ::env(SYNTH_TIELO_PORT) "sky130_fd_sc_hvl__conb_1 LO"
 
 # cts defaults
-set ::env(CTS_ROOT_BUFFER) ""
-#set ::env(CELL_CLK_PORT) CLK
+set ::env(CTS_ROOT_BUFFER) sky130_fd_sc_hvl__buf_16
+set ::env(CELL_CLK_PORT) CLK
 
 # Placement defaults
 set ::env(PL_LIB) $::env(LIB_TYPICAL)
@@ -58,4 +58,12 @@ set ::env(CELL_PAD) 8
 set ::env(CELL_PAD_EXECLUDE) "sky130_fd_sc_hvl__tap* sky130_fd_sc_hvl__decap* sky130_fd_sc_hvl__fill*"
 
 # Clk Buffers info CTS data
-set ::env(CLOCK_TREE_SYNTH) 0
+set ::env(ROOT_CLK_BUFFER) sky130_fd_sc_hvl__buf_16
+set ::env(CLK_BUFFER) sky130_fd_sc_hvl__buf_4
+set ::env(CLK_BUFFER_INPUT) A
+set ::env(CLK_BUFFER_OUTPUT) X
+
+set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hvl__buf_1 sky130_fd_sc_hvl__buf_2 sky130_fd_sc_hvl__buf_4 sky130_fd_sc_hvl__buf_8"
+set ::env(CTS_MAX_CAP) 5.57100
+
+set ::env(PDN_RAIL_WIDTH) 0.51

--- a/sky130/openlane/sky130_fd_sc_ls/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ls/config.tcl
@@ -65,3 +65,5 @@ set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_ls__clkbuf_1 sky130_fd_sc_ls__clkbu
 set ::env(CTS_SQR_CAP) 0.258e-3
 set ::env(CTS_SQR_RES) 0.125
 set ::env(CTS_MAX_CAP) 1.53169
+
+set ::env(PDN_RAIL_WIDTH) 0.48

--- a/sky130/openlane/sky130_fd_sc_ls/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ls/config.tcl
@@ -66,4 +66,4 @@ set ::env(CTS_SQR_CAP) 0.258e-3
 set ::env(CTS_SQR_RES) 0.125
 set ::env(CTS_MAX_CAP) 1.53169
 
-set ::env(PDN_RAIL_WIDTH) 0.48
+set ::env(FP_PDN_RAIL_WIDTH) 0.48

--- a/sky130/openlane/sky130_fd_sc_ms/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ms/config.tcl
@@ -67,4 +67,4 @@ set ::env(CTS_SQR_CAP) 0.258e-3
 set ::env(CTS_SQR_RES) 0.125
 set ::env(CTS_MAX_CAP) 1.53169
 
-set ::env(PDN_RAIL_WIDTH) 0.48
+set ::env(FP_PDN_RAIL_WIDTH) 0.48

--- a/sky130/openlane/sky130_fd_sc_ms/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ms/config.tcl
@@ -66,3 +66,5 @@ set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_ms__clkbuf_2 sky130_fd_sc_ms__clkbu
 set ::env(CTS_SQR_CAP) 0.258e-3
 set ::env(CTS_SQR_RES) 0.125
 set ::env(CTS_MAX_CAP) 1.53169
+
+set ::env(PDN_RAIL_WIDTH) 0.48


### PR DESCRIPTION
- introduced `PDN_RAIL_WIDTH` to replace the hardcoded 0.48 value in common_pdn.tcl and updated it for all variants.
- Added CTS configs for HVL using normal buffers.