### PR TITLE
base commit for travisCI auto testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ scripts/*
 **/Makefile
 **/Makefile.am
 
+# exceptions for travisCI
+!.travisCI/Makefile
+
 # staged PDKs
 sky130/sky130A
 sky130/sky130A/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+# Copyright 2020 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: minimal
+
+
+services:
+    - docker
+
+os:
+  - linux
+
+jobs:
+  include:
+    - name: "hd library"
+      env: STD_CELL_LIBRARY=sky130_fd_sc_hd
+    - name: "hs library"
+      env: STD_CELL_LIBRARY=sky130_fd_sc_hs
+    - name: "ms library"
+      env: STD_CELL_LIBRARY=sky130_fd_sc_ms
+    - name: "ls library"
+      env: STD_CELL_LIBRARY=sky130_fd_sc_ls
+    - name: "hdll library"
+      env: STD_CELL_LIBRARY=sky130_fd_sc_hdll
+    - name: "all libraries"
+      env: STD_CELL_LIBRARY=all
+  allow_failures:
+    - name: "all libraries"
+      env: STD_CELL_LIBRARY=all
+
+install:
+  - bash .travisCI/travisBuild.sh
+
+script:
+  - bash .travisCI/travisTest.sh

--- a/.travisCI/Dockerfile
+++ b/.travisCI/Dockerfile
@@ -1,0 +1,61 @@
+# Copyright 2020 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# syntax = docker/dockerfile:1.0-experimental
+FROM centos:centos6 as build
+
+# Common development tools and libraries (kitchen sink approach)
+RUN yum groupinstall -y "Development Tools" "Development Libraries"
+RUN yum -y install centos-release-scl && \
+    yum -y install devtoolset-8 devtoolset-8-libatomic-devel
+
+# python 3.6
+RUN yum install -y https://repo.ius.io/ius-release-el6.rpm
+RUN yum install -y python36u python36u-libs python36u-devel python36u-pip python36u-tkinter
+RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 60
+
+# magic dependencies
+RUN yum install -y csh wget tcl-devel tk-devel libX11-devel cairo-devel ncurses-devel
+
+#General utils
+RUN yum install -y tcllib
+RUN yum install -y git tcl tk libjpeg libgomp libXext libSM libXft libffi cairo gettext Xvfb
+
+RUN git clone git://opencircuitdesign.com/magic magic_15102020
+
+WORKDIR magic_15102020
+
+RUN git checkout 4bbe4ef74e5eac98c503bf6483ee7a40dbb0547a
+
+# build
+RUN ./configure --prefix=/build && \
+    make -j4 && \
+    make install
+
+
+ENV MAGIC_ROOT=/magic_root
+ENV BUILD_PATH=/build/
+
+ENV PATH=$MAGIC_ROOT:$MAGIC_ROOT/scripts:$BUILD_PATH/bin:$BUILD_PATH/bin/Linux-x86_64:$BUILD_PATH/pdn/scripts:$PATH
+ENV LD_LIBRARY_PATH=$BUILD_PATH/lib:$BUILD_PATH/lib/Linux-x86_64:$LD_LIBRARY_PATH
+ENV MANPATH=$BUILD_PATH/share/man:$MANPATH
+
+
+RUN mkdir -p /build/version/
+
+RUN date +"Build Timestamp: %Y-%m-%d_%H-%M-%S" > /build/version/magic.version
+RUN git rev-parse HEAD >> /build/version/magic.version
+RUN tar -czf /build.tar.gz /build
+
+WORKDIR /magic_root

--- a/.travisCI/Makefile
+++ b/.travisCI/Makefile
@@ -1,0 +1,66 @@
+# Copyright 2020 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adopted from OpenLANE's Makefile.
+
+OPEN_PDKS_ROOT ?= $(shell pwd)/..
+THREADS ?= $(shell nproc)
+STD_CELL_LIBRARY ?= sky130_fd_sc_hd
+SKYWATER_COMMIT ?= 5cd70ed19fee8ea37c4e8dbd5c5c3eaa9886dd23
+
+.DEFAULT_GOAL := all
+
+.PHONY: all
+all: pdk
+
+.PHONY: pdk
+pdk: skywater-pdk skywater-library build-pdk
+
+$(PDK_ROOT)/skywater-pdk:
+	git clone https://github.com/google/skywater-pdk.git $(PDK_ROOT)/skywater-pdk
+
+.PHONY: skywater-pdk
+skywater-pdk: $(PDK_ROOT)/skywater-pdk
+	cd $(PDK_ROOT)/skywater-pdk && \
+		git checkout -qf $(SKYWATER_COMMIT)
+
+.PHONY: skywater-library
+skywater-library: $(PDK_ROOT)/skywater-pdk
+	cd $(PDK_ROOT)/skywater-pdk && \
+		git submodule update --init libraries/$(STD_CELL_LIBRARY)/latest && \
+		$(MAKE) -j$(THREADS) $(STD_CELL_LIBRARY)
+
+.PHONY: all-skywater-libraries
+all-skywater-libraries: skywater-pdk
+	cd $(PDK_ROOT)/skywater-pdk && \
+		git submodule update --init libraries/sky130_fd_sc_hd/latest && \
+		git submodule update --init libraries/sky130_fd_sc_hs/latest && \
+		git submodule update --init libraries/sky130_fd_sc_hdll/latest && \
+		git submodule update --init libraries/sky130_fd_sc_ms/latest && \
+		git submodule update --init libraries/sky130_fd_sc_ls/latest && \
+		$(MAKE) -j$(THREADS) timing
+
+.PHONY: build-pdk
+build-pdk: $(PDK_ROOT)/skywater-pdk
+	[[ -d $(PDK_ROOT)/sky130A ]] && \
+		(echo "Warning: A sky130A build already exists under $(PDK_ROOT). It will be deleted first!" && \
+		sleep 5 && \
+		rm -rf $(PDK_ROOT)/sky130A) || \
+		true
+	cd $(OPEN_PDKS_ROOT) && \
+		./configure --with-sky130-source=$(PDK_ROOT)/skywater-pdk/libraries --with-sky130-local-path=$(PDK_ROOT) && \
+		cd sky130 && \
+		$(MAKE) veryclean && \
+		$(MAKE) && \
+		$(MAKE) install-local

--- a/.travisCI/build-docker.sh
+++ b/.travisCI/build-docker.sh
@@ -1,0 +1,21 @@
+# Copyright 2020 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# exit when any command fails
+set -e
+
+mkdir -p logs/docker
+echo "dir created"
+docker build --rm -t magic . | tee logs/docker/magic.build.txt
+

--- a/.travisCI/travisBuild.sh
+++ b/.travisCI/travisBuild.sh
@@ -1,0 +1,31 @@
+# Copyright 2020 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# exit when any command fails
+set -e
+
+mkdir pdks
+export OPEN_PDKS_ROOT=$(pwd)
+export PDK_ROOT=$(pwd)/pdks
+cd ./.travisCI
+sh ./build-docker.sh > /dev/null
+make skywater-pdk > /dev/null
+if [ $STD_CELL_LIBRARY == all ]; then
+    make all-skywater-libraries;
+else
+    make skywater-library;
+fi
+cd ..
+docker run -it -v $(pwd):/some_root -v $(pwd)/.travisCI:/build_root -v $OPEN_PDKS_ROOT:$OPEN_PDKS_ROOT -v $PDK_ROOT:$PDK_ROOT -e OPEN_PDKS_ROOT=$OPEN_PDKS_ROOT -e PDK_ROOT=$PDK_ROOT -u $(id -u $USER):$(id -g $USER) magic:latest  bash -c "cd /build_root && make build-pdk"
+exit 0

--- a/.travisCI/travisTest.sh
+++ b/.travisCI/travisTest.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2020 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if ! [[ -d $(pwd)/pdks/sky130A ]]; then exit -1; fi
+
+SIZE=$(du -sb $(pwd)/pdks/sky130A | cut -f1)
+# 250MB = 262,144,000 bytes; a fair estimate of the size of one library, I guess.
+if [[ $SIZE -lt 262144000 ]]; then
+    echo 'size is less than 250MB'
+    exit -1
+fi
+echo 'Built without fatal errors'
+echo "sky130A size is $SIZE bytes"
+exit 0


### PR DESCRIPTION
This is a working travisCI testing setup for open_pdks. This should check all pushes and pull requests to make sure that nothing breaks the build.

currently, the jobs are:
1. build hd library alone
2. hs
3. ms
4. hdll
5. ls
6. build all libraries together.

More jobs should be added when more libraries are added to the skywater-pdk public repo.

What it does:
1. build a magic docker container.
2. clone skywater-pdk and update the desired submodule
3. build open_pdks (invoke configure and make, from within the docker container)
4. Check if any fatal error happened during the build.
5. Check if the produced files have a sensible size (bigger than 250MB)

What you need to do to activate this from your side (@RTimothyEdwards):
1. go to https://travis-ci.com signup with your github account and link it.
That's it, enjoy the dashboard and the green ticks.

I'll be maintaining it every once in a while, if anything needs to be changed or added to the setup.

One downside of it is that you'll have to email support@travis-ci.com and tell them:
```
Dears,
   One job in my test-suite is long by nature because it builds multiple libraries using the tool in this repo: https://github.com/RTimothyEdwards/open_pdks

So, Could you increase the timeout for a job? Because 50 minutes is too short for us, and we cannot reduce the runtime in any way. Also, if you could increase the maximum job log to 5 or 6 MB.

My account name is: RTimothyEdwards
```

This is because the build process of job 6 (all the libraries together) takes about an hour, and produces a log that is bigger than 4MB (the maximum allowed).
For now, I set job 6 as an (allow_failures) job because it will eventually timeout, but at the same time, it would be useful to see if it broke/failed before it times out.

This tests the version on github only, and is activated on PRs and pushes to any of the branches.

Let me know if you want me to change/enhance/update anything!