### PR TITLE
Modifications related to the installation of the I/O library

### DIFF
--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -374,6 +374,13 @@ vendor-a:
 	# Custom:  Add "short" resistor model to the r+c models file
 	cat ./custom/models/short.spice >> \
 		${STAGING_PATH}/${SKY130A}/libs.tech/ngspice/sky130_fd_pr__model__r+c.model.spice 
+	# Install custom additions to I/O pad library
+	${STAGE} -source ./custom -target ${STAGING_PATH}/${SKY130A} \
+		-verilog %l/verilog/*.v \
+		-cdl %l/cdl/*.cdl \
+		-gds %l/gds/*.gds \
+		-lef %l/lef/*.lef compile-only rename=sky130_ef_io \
+		-library general sky130_fd_io |& tee -a ${SKY130A}_install.log
 	# Install SkyWater I/O pad library
 	${STAGE} -source ${SKYWATER_PATH} -target ${STAGING_PATH}/${SKY130A} \
 		-spice %l/latest/cells/*/*.spice compile-only \
@@ -394,13 +401,6 @@ vendor-a:
 	# Remove the base verilog files which have already been included into
 	# the libraries
 	${RM} ${STAGING_PATH}/${SKY130A}/libs.ref/sky130_fd_io/verilog/*.*.v
-	# Install custom additions to I/O pad library
-	${STAGE} -source ./custom -target ${STAGING_PATH}/${SKY130A} \
-		-verilog %l/verilog/*.v \
-		-cdl %l/cdl/*.cdl \
-		-gds %l/gds/*.gds \
-		-lef %l/lef/*.lef compile-only \
-		-library general sky130_fd_io |& tee -a ${SKY130A}_install.log
 	# Install all SkyWater digital standard cells.
 	${STAGE} -source ${SKYWATER_PATH} -target ${STAGING_PATH}/${SKY130A} \
 		-techlef %l/latest/tech/*.tlef \
@@ -447,7 +447,7 @@ vendor-a:
 		-library digital sky130_osu_sc_t18 |& tee -a ${SKY130A}_install.log
 	# Renaming.  Can it be avoided or simplified ?
 	${MV} ${STAGING_PATH}/${SKY130A}/libs.ref/sky130_osu_sc_t18/techlef/sky130_osu_sc.tlef ${STAGING_PATH}/${SKY130A}/libs.ref/sky130_osu_sc_t18/techlef/sky130_osu_sc_t18.tlef
-        # Install OSU digital standard cells.
+	# Install OSU digital standard cells.
 	# ${STAGE} -source ${OSU_PATH} -target ${STAGING_PATH}/${SKY130A} \
 	# 	-techlef char/techfiles/scs8.lef rename sky130_osu_sc.tlef \
 	# 	-spice lib/spice/*.spice compile-only \

--- a/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssa_hvc_pad.lef
+++ b/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssa_hvc_pad.lef
@@ -3,7 +3,7 @@ VERSION 5.7 ;
   DIVIDERCHAR "/" ;
   BUSBITCHARS "[]" ;
 MACRO sky130_ef_io__vssa_hvc_pad
-  CLASS PAD GROUND ;
+  CLASS PAD POWER ;
   FOREIGN sky130_ef_io__vssa_hvc_pad ;
   ORIGIN 0.000 0.000 ;
   SIZE 75.000 BY 197.965 ;

--- a/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssa_lvc_pad.lef
+++ b/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssa_lvc_pad.lef
@@ -3,7 +3,7 @@ VERSION 5.7 ;
   DIVIDERCHAR "/" ;
   BUSBITCHARS "[]" ;
 MACRO sky130_ef_io__vssa_lvc_pad
-  CLASS PAD GROUND ;
+  CLASS PAD POWER ;
   FOREIGN sky130_ef_io__vssa_lvc_pad ;
   ORIGIN 0.000 0.000 ;
   SIZE 75.000 BY 197.965 ;

--- a/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssd_hvc_pad.lef
+++ b/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssd_hvc_pad.lef
@@ -3,7 +3,7 @@ VERSION 5.7 ;
   DIVIDERCHAR "/" ;
   BUSBITCHARS "[]" ;
 MACRO sky130_ef_io__vssd_hvc_pad
-  CLASS PAD GROUND ;
+  CLASS PAD POWER ;
   FOREIGN sky130_ef_io__vssd_hvc_pad ;
   ORIGIN 0.000 0.000 ;
   SIZE 75.000 BY 197.965 ;

--- a/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssd_lvc_pad.lef
+++ b/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssd_lvc_pad.lef
@@ -3,7 +3,7 @@ VERSION 5.7 ;
   DIVIDERCHAR "/" ;
   BUSBITCHARS "[]" ;
 MACRO sky130_ef_io__vssd_lvc_pad
-  CLASS PAD GROUND ;
+  CLASS PAD POWER ;
   FOREIGN sky130_ef_io__vssd_lvc_pad ;
   ORIGIN 0.000 0.000 ;
   SIZE 75.000 BY 197.965 ;

--- a/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssio_hvc_pad.lef
+++ b/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssio_hvc_pad.lef
@@ -3,7 +3,7 @@ VERSION 5.7 ;
   DIVIDERCHAR "/" ;
   BUSBITCHARS "[]" ;
 MACRO sky130_ef_io__vssio_hvc_pad
-  CLASS PAD GROUND ;
+  CLASS PAD POWER ;
   FOREIGN sky130_ef_io__vssio_hvc_pad ;
   ORIGIN 0.000 0.000 ;
   SIZE 75.000 BY 197.965 ;

--- a/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssio_lvc_pad.lef
+++ b/sky130/custom/sky130_fd_io/lef/sky130_ef_io__vssio_lvc_pad.lef
@@ -3,7 +3,7 @@ VERSION 5.7 ;
   DIVIDERCHAR "/" ;
   BUSBITCHARS "[]" ;
 MACRO sky130_ef_io__vssio_lvc_pad
-  CLASS PAD GROUND ;
+  CLASS PAD POWER ;
   FOREIGN sky130_ef_io__vssio_lvc_pad ;
   ORIGIN 0.000 0.000 ;
   SIZE 75.000 BY 197.965 ;

--- a/sky130/openlane/config.tcl
+++ b/sky130/openlane/config.tcl
@@ -12,11 +12,20 @@ set ::env(GND_PIN) "VGND"
 #ifdef EF_FORMAT
 set ::env(TECH_LEF) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/techLEF/$::env(STD_CELL_LIBRARY)/$::env(STD_CELL_LIBRARY).tlef"
 set ::env(CELLS_LEF) [glob "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lef/$::env(STD_CELL_LIBRARY)/*.lef"]
-set ::env(GPIO_PADS_LEF) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lef/sky130_fd_io/sky130_fd_io.lef"
+set ::env(GPIO_PADS_LEF) "\
+	$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lef/sky130_fd_io/sky130_fd_io.lef\
+	$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lef/sky130_fd_io/sky130_ef_io.lef\
+	"
+# sky130_fd_io.v is not parsable by yosys, so it cannot be included it here yet...
+set ::env(GPIO_PADS_VERILOG) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/verilog/sky130_fd_io/sky130_ef_io.v"
 #else (!EF_FORMAT)
 set ::env(TECH_LEF) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/techlef/$::env(STD_CELL_LIBRARY).tlef"
 set ::env(CELLS_LEF) [glob "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lef/*.lef"]
-set ::env(GPIO_PADS_LEF) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lef/sky130_fd_io.lef"
+set ::env(GPIO_PADS_LEF) "\
+	$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lef/sky130_fd_io.lef\
+	$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lef/sky130_ef_io.lef\
+	"
+set ::env(GPIO_PADS_VERILOG) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/verilog/sky130_ef_io.v"
 #endif (!EF_FORMAT)
 
 # magic setup


### PR DESCRIPTION
I am installing the custom additions first because otherwise, on my end, the compiled LEF file would get compiled to `library_name.lef` (`sky130_fd_io.lef`) overwriting the pre-existing original LEF.