### PR TITLE
control the global_connections section in common_pdn.tcl with a flag

### DIFF
--- a/sky130/openlane/common_pdn.tcl
+++ b/sky130/openlane/common_pdn.tcl
@@ -2,16 +2,20 @@
 set ::power_nets $::env(VDD_PIN)
 set ::ground_nets $::env(GND_PIN)
 
-# to parameterize -- needs a PDNGEN fix
-set pdngen::global_connections {
-  VPWR {
-    {inst_name .* pin_name VPWR}
-    {inst_name .* pin_name VPB}
-  }
-  VGND {
-    {inst_name .* pin_name VGND}
-    {inst_name .* pin_name VNB}
-  }
+if { [info exists ::env(FP_PDN_ENABLE_GLOBAL_CONNECTIONS)] } {
+    if { $::env(FP_PDN_ENABLE_GLOBAL_CONNECTIONS) == 1 } {        
+        # to parameterize -- needs a PDNGEN fix
+        set pdngen::global_connections {
+            VPWR {
+                {inst_name .* pin_name VPWR}
+                {inst_name .* pin_name VPB}
+            }
+            VGND {
+                {inst_name .* pin_name VGND}
+                {inst_name .* pin_name VNB}
+            }
+        }
+    }
 }
 
 # Used if the design is the core of the chip


### PR DESCRIPTION
This section causes trouble for OpenSTA because it's unable to deal with the power connections when they are too many for some reason. This needs to be opened as an issue on the OpenROAD side. However, let's apply this quick workaround for now since this section isn't really needed for most of the designs.