### PR TITLE
Add a default None value for tclscript

### DIFF
--- a/common/foundry_install.py
+++ b/common/foundry_install.py
@@ -1049,6 +1049,7 @@ if __name__ == '__main__':
     # then migrate them to magic (.mag files in layout/ or abstract/).
 
     ignorelist = []
+    tclscript = None
     do_cdl_scaleu  = False
     no_cdl_convert = False
     no_gds_convert = False


### PR DESCRIPTION
Otherwise, things like https://github.com/RTimothyEdwards/open_pdks/blob/master/common/foundry_install.py#L1235 would be referencing a non-existent variable.