### PR TITLE
Ignore 236/0

### DIFF
--- a/sky130/magic/sky130.tech
+++ b/sky130/magic/sky130.tech
@@ -2226,6 +2226,7 @@ style  sky130 variants (),(vendor)
  ignore POLYMOD
  ignore LOWTAPDENSITY
  ignore FILLOBSPOLY
+ ignore OUTLINE
 
  layer pnp NWELL,WELLTXT,WELLPIN
  and PNPID
@@ -3826,6 +3827,8 @@ style  sky130 variants (),(vendor)
  calma BOUND 235 4
 
  calma LVSTEXT 83 44
+
+ calma OUTLINE 236 0
 
 #ifdef (MIM)
  calma CAPM 89 44


### PR DESCRIPTION
During DRC checking of a design I see a lot of:

Error while reading cell "sky130_fd_sc_hd__o21a_4" (byte position 147754): Unknown layer/datatype in boundary, layer=236 type=0

236/0 appears to be an outline layer. Tell magic to ignore it.