### PR TITLE
Don't recursively expand SKYWATER_PATH

### DIFF
--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -157,7 +157,7 @@ LINK_TARGETS = @SKY130_LINK_TARGETS@
 # Path to skywater_pdk 
 SKYWATER_PATH = @SKY130_SOURCE_PATH@
 ifneq ($(SKYWATER_PATH),)
-SKYWATER_PATH = $(SKYWATER_PATH)/libraries
+    SKYWATER_PATH := $(SKYWATER_PATH)/libraries
 endif
 
 # Path to OSU standard cell library sources (to be added to configuration options).


### PR DESCRIPTION
Otherwise, the following error occurs:
```
Makefile:160: *** Recursive variable `SKYWATER_PATH' references itself
```