### PR TITLE
Minor openlane config update

### DIFF
--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -157,7 +157,7 @@ LINK_TARGETS = @SKY130_LINK_TARGETS@
 
 # Paths:
 
-# Path to skywater_pdk 
+# Path to skywater_pdk
 SKYWATER_PATH = @SKY130_SOURCE_PATH@
 ifneq ($(SKYWATER_PATH),)
     SKYWATER_PATH := $(SKYWATER_PATH)/libraries
@@ -445,27 +445,33 @@ openlane-a: openlane/common_pdn.tcl openlane/config.tcl openlane/sky130_fd_sc_hd
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hd/config.tcl > ${OPENLANE_STAGING_A}/sky130_fd_sc_hd/config.tcl
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hd/tracks.info > ${OPENLANE_STAGING_A}/sky130_fd_sc_hd/tracks.info
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hd/no_synth.cells > ${OPENLANE_STAGING_A}/sky130_fd_sc_hd/no_synth.cells
-	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hd/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hd/tribuff_map.v 
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hd/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hd/tribuff_map.v
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hd/latch_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hd/latch_map.v
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hs/config.tcl > ${OPENLANE_STAGING_A}/sky130_fd_sc_hs/config.tcl
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hs/tracks.info > ${OPENLANE_STAGING_A}/sky130_fd_sc_hs/tracks.info
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hs/no_synth.cells > ${OPENLANE_STAGING_A}/sky130_fd_sc_hs/no_synth.cells
-	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hs/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hs/tribuff_map.v 
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hs/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hs/tribuff_map.v
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hs/latch_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hs/latch_map.v
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ms/config.tcl > ${OPENLANE_STAGING_A}/sky130_fd_sc_ms/config.tcl
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ms/tracks.info > ${OPENLANE_STAGING_A}/sky130_fd_sc_ms/tracks.info
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ms/no_synth.cells > ${OPENLANE_STAGING_A}/sky130_fd_sc_ms/no_synth.cells
-	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ms/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_ms/tribuff_map.v 
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ms/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_ms/tribuff_map.v
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ms/latch_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_ms/latch_map.v
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ls/config.tcl > ${OPENLANE_STAGING_A}/sky130_fd_sc_ls/config.tcl
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ls/tracks.info > ${OPENLANE_STAGING_A}/sky130_fd_sc_ls/tracks.info
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ls/no_synth.cells > ${OPENLANE_STAGING_A}/sky130_fd_sc_ls/no_synth.cells
-	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ls/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_ls/tribuff_map.v 
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ls/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_ls/tribuff_map.v
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_ls/latch_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_ls/latch_map.v
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hdll/config.tcl > ${OPENLANE_STAGING_A}/sky130_fd_sc_hdll/config.tcl
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hdll/tracks.info > ${OPENLANE_STAGING_A}/sky130_fd_sc_hdll/tracks.info
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hdll/no_synth.cells > ${OPENLANE_STAGING_A}/sky130_fd_sc_hdll/no_synth.cells
-	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hdll/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hdll/tribuff_map.v 
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hdll/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hdll/tribuff_map.v
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hdll/latch_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hdll/latch_map.v
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hvl/config.tcl > ${OPENLANE_STAGING_A}/sky130_fd_sc_hvl/config.tcl
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hvl/tracks.info > ${OPENLANE_STAGING_A}/sky130_fd_sc_hvl/tracks.info
 	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hvl/no_synth.cells > ${OPENLANE_STAGING_A}/sky130_fd_sc_hvl/no_synth.cells	
-	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hvl/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hvl/tribuff_map.v 
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hvl/tribuff_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hvl/tribuff_map.v
+	${CPP} ${SKY130A_DEFS} openlane/sky130_fd_sc_hvl/latch_map.v > ${OPENLANE_STAGING_A}/sky130_fd_sc_hvl/latch_map.v
 	${CPP} ${SKY130A_DEFS} openlane/sky130_osu_sc_t18/config.tcl > ${OPENLANE_STAGING_A}/sky130_osu_sc_t18/config.tcl
 	${CPP} ${SKY130A_DEFS} openlane/sky130_osu_sc_t18/tracks.info > ${OPENLANE_STAGING_A}/sky130_osu_sc_t18/tracks.info
 
@@ -485,10 +491,10 @@ vendor-a:
 		-library primitive sky130_fd_pr |& tee -a ${SKY130A}_install.log
 	# Custom:  Add "short" resistor model and subcircuit to the r+c models file
 	cat ./custom/models/short.spice >> \
-		${STAGING_PATH}/${SKY130A}/libs.tech/ngspice/sky130_fd_pr__model__r+c.model.spice 
+		${STAGING_PATH}/${SKY130A}/libs.tech/ngspice/sky130_fd_pr__model__r+c.model.spice
 	# Custom:  Add diodes as subcircuits to the r+c models file
 	cat ./custom/models/diode.spice >> \
-		${STAGING_PATH}/${SKY130A}/libs.tech/ngspice/sky130_fd_pr__model__r+c.model.spice 
+		${STAGING_PATH}/${SKY130A}/libs.tech/ngspice/sky130_fd_pr__model__r+c.model.spice
 
 	# Install custom additions to I/O pad library
 	${STAGE} -source ./custom -target ${STAGING_PATH}/${SKY130A} \

--- a/sky130/openlane/sky130_fd_sc_hd/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hd/config.tcl
@@ -50,7 +50,7 @@ set ::env(DIODE_CELL) "sky130_fd_sc_hd__diode_2"
 set ::env(FAKEDIODE_CELL) "sky130_ef_sc_hd__fakediode_2"
 set ::env(DIODE_CELL_PIN) "DIODE"
 
-set ::env(CELL_PAD) 8
+set ::env(CELL_PAD) 4
 set ::env(CELL_PAD_EXCLUDE) "sky130_fd_sc_hd__tap* sky130_fd_sc_hd__decap* sky130_fd_sc_hd__fill*"
 
 # Clk Buffers info CTS data

--- a/sky130/openlane/sky130_fd_sc_hd/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hd/config.tcl
@@ -13,6 +13,9 @@ set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LI
 
 set ::env(LIB_TYPICAL) $::env(LIB_SYNTH)
 
+# Default No Synth List
+set ::env(NO_SYNTH_LIST) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells"
+
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unithd"

--- a/sky130/openlane/sky130_fd_sc_hdll/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hdll/config.tcl
@@ -13,6 +13,9 @@ set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LI
 
 set ::env(LIB_TYPICAL) $::env(LIB_SYNTH)
 
+# Default No Synth List
+set ::env(NO_SYNTH_LIST) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells"
+
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unithd"

--- a/sky130/openlane/sky130_fd_sc_hdll/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hdll/config.tcl
@@ -50,7 +50,7 @@ set ::env(DIODE_CELL) "sky130_fd_sc_hdll__diode_2"
 set ::env(FAKEDIODE_CELL) "sky130_fd_sc_hdll__fakediode_2"
 set ::env(DIODE_CELL_PIN) "DIODE"
 
-set ::env(CELL_PAD) 8
+set ::env(CELL_PAD) 4
 set ::env(CELL_PAD_EXCLUDE) "$::env(STD_CELL_LIBRARY)__tap* $::env(STD_CELL_LIBRARY)__decap* $::env(STD_CELL_LIBRARY)__fill*"
 
 # Clk Buffers info CTS data

--- a/sky130/openlane/sky130_fd_sc_hs/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hs/config.tcl
@@ -13,6 +13,9 @@ set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LI
 
 set ::env(LIB_TYPICAL) $::env(LIB_SYNTH)
 
+# Default No Synth List
+set ::env(NO_SYNTH_LIST) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells"
+
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unit"

--- a/sky130/openlane/sky130_fd_sc_hs/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hs/config.tcl
@@ -48,7 +48,7 @@ set ::env(DECAP_CELL) "sky130_fd_sc_hs__decap_"
 set ::env(DIODE_CELL) "sky130_fd_sc_hs__diode_2"
 set ::env(DIODE_CELL_PIN) "DIODE"
 
-set ::env(CELL_PAD) 8
+set ::env(CELL_PAD) 4
 set ::env(CELL_PAD_EXCLUDE) "sky130_fd_sc_hs__tap* sky130_fd_sc_hs__decap* sky130_fd_sc_hs__fill*"
 
 set ::env(ROOT_CLK_BUFFER) sky130_fd_sc_hs__clkbuf_16

--- a/sky130/openlane/sky130_fd_sc_hvl/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hvl/config.tcl
@@ -55,7 +55,7 @@ set ::env(RE_BUFFER_CELL) "sky130_fd_sc_hvl__buf_1"
 set ::env(DIODE_CELL) "sky130_fd_sc_hvl__diode_2"
 set ::env(DIODE_CELL_PIN) "DIODE"
 
-set ::env(CELL_PAD) 8
+set ::env(CELL_PAD) 4
 set ::env(CELL_PAD_EXCLUDE) "sky130_fd_sc_hvl__tap* sky130_fd_sc_hvl__decap* sky130_fd_sc_hvl__fill*"
 
 # Clk Buffers info CTS data

--- a/sky130/openlane/sky130_fd_sc_hvl/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hvl/config.tcl
@@ -19,6 +19,9 @@ set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LI
 
 set ::env(LIB_TYPICAL) $::env(LIB_SYNTH)
 
+# Default No Synth List
+set ::env(NO_SYNTH_LIST) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells"
+
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unithv"

--- a/sky130/openlane/sky130_fd_sc_ls/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ls/config.tcl
@@ -13,6 +13,9 @@ set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LI
 
 set ::env(LIB_TYPICAL) $::env(LIB_SYNTH)
 
+# Default No Synth List
+set ::env(NO_SYNTH_LIST) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells"
+
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unit"

--- a/sky130/openlane/sky130_fd_sc_ls/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ls/config.tcl
@@ -50,7 +50,7 @@ set ::env(DIODE_CELL) "sky130_fd_sc_ls__diode_2"
 set ::env(FAKEDIODE_CELL) "sky130_fd_sc_ls__fakediode_2"
 set ::env(DIODE_CELL_PIN) "DIODE"
 
-set ::env(CELL_PAD) 8
+set ::env(CELL_PAD) 4
 set ::env(CELL_PAD_EXCLUDE) "$::env(STD_CELL_LIBRARY)__tap* $::env(STD_CELL_LIBRARY)__decap* $::env(STD_CELL_LIBRARY)__fill*"
 
 # Clk Buffers info CTS data

--- a/sky130/openlane/sky130_fd_sc_ms/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ms/config.tcl
@@ -13,6 +13,10 @@ set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LI
 
 set ::env(LIB_TYPICAL) $::env(LIB_SYNTH)
 
+# Default No Synth List
+set ::env(NO_SYNTH_LIST) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells"
+
+
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unit"

--- a/sky130/openlane/sky130_fd_sc_ms/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ms/config.tcl
@@ -49,7 +49,7 @@ set ::env(RE_BUFFER_CELL) "sky130_fd_sc_ms__buf_4"
 set ::env(DIODE_CELL) "sky130_fd_sc_ms__diode_2"
 set ::env(DIODE_CELL_PIN) "DIODE"
 
-set ::env(CELL_PAD) 8
+set ::env(CELL_PAD) 4
 set ::env(CELL_PAD_EXCLUDE) "$::env(STD_CELL_LIBRARY)__tap* $::env(STD_CELL_LIBRARY)__decap* $::env(STD_CELL_LIBRARY)__fill*"
 
 # Clk Buffers info CTS data

--- a/sky130/openlane/sky130_osu_sc_t18/config.tcl
+++ b/sky130/openlane/sky130_osu_sc_t18/config.tcl
@@ -56,7 +56,7 @@ set ::env(DIODE_CELL) "ANTFILL"
 #set ::env(FAKEDIODE_CELL) "sky130_osu_sc_t18__fakediode_2"
 set ::env(DIODE_CELL_PIN) "A"
 
-set ::env(CELL_PAD) 8
+set ::env(CELL_PAD) 4
 set ::env(CELL_PAD_EXECLUDE) "FILLX*"
 
 # Clk Buffers info CTS data


### PR DESCRIPTION
- Reduce default cell padding to 4.
- Add a pointer to no_synth.cells in each library config. This is the first step at aggressively reducing the no_synth list and allowing for a design specific list.
- Copy latch_map.v to the sky130A directory..