### PR TITLE
Openlane updates

### DIFF
--- a/sky130/magic/sky130.tech
+++ b/sky130/magic/sky130.tech
@@ -1977,7 +1977,7 @@ style wafflefill variants (),(tiled)
         grow    3000
  templayer	met1fill_coarse topbox
         # slots   0 2000 200 0 2000 200 700 0
-        slots   0 2000 600 0 2000 600 700 350
+        slots   0 2000 800 0 2000 800 700 350
         and-not obstruct_m1_coarse
 	and	topbox
         shrink  995
@@ -2029,7 +2029,7 @@ style wafflefill variants (),(tiled)
         grow    3000
  templayer	met2fill_coarse topbox
         # slots   0 2000 200 0 2000 200 700 350
-        slots   0 2000 600 0 2000 600 700 350
+        slots   0 2000 800 0 2000 800 700 350
         and-not obstruct_m2
 	and	topbox
         shrink  995
@@ -2081,7 +2081,7 @@ style wafflefill variants (),(tiled)
         grow    3000
  templayer	met3fill_coarse topbox
         # slots   0 2000 300 0 2000 300 700 700
-        slots   0 2000 600 0 2000 600 700 350
+        slots   0 2000 800 0 2000 800 700 350
         and-not obstruct_m3
 	and	topbox
         shrink  995
@@ -2135,7 +2135,7 @@ style wafflefill variants (),(tiled)
         grow    3000
  templayer	met4fill_coarse topbox
         # slots   0 2000 300 0 2000 300 700 1050
-        slots   0 2000 600 0 2000 600 700 350
+        slots   0 2000 800 0 2000 800 700 350
         and-not obstruct_m4
 	and	topbox
         shrink  995

--- a/sky130/openlane/sky130_fd_sc_hd/drc_exclude.cells
+++ b/sky130/openlane/sky130_fd_sc_hd/drc_exclude.cells
@@ -42,6 +42,7 @@ sky130_fd_sc_hd__o21ai_0
 sky130_fd_sc_hd__o311ai_0
 sky130_fd_sc_hd__or2_0
 sky130_fd_sc_hd__probe_p_8
+sky130_fd_sc_hd__probec_p_8
 sky130_fd_sc_hd__xor3_1
 sky130_fd_sc_hd__xor3_2
 sky130_fd_sc_hd__xor3_4

--- a/sky130/openlane/sky130_fd_sc_hd/mux2_map.v
+++ b/sky130/openlane/sky130_fd_sc_hd/mux2_map.v
@@ -4,7 +4,7 @@ module \$_MUX_ (
     input B,
     input S
     );
-  sky130_fd_sc_hd__mux2_4 _TECHMAP_MUX (
+  sky130_fd_sc_hd__mux2_1 _TECHMAP_MUX (
       .X(Y),
       .A0(A),
       .A1(B),

--- a/sky130/openlane/sky130_fd_sc_hd/mux4_map.v
+++ b/sky130/openlane/sky130_fd_sc_hd/mux4_map.v
@@ -7,7 +7,7 @@ module \$_MUX4_ (
     input S,
     input T
     );
-  sky130_fd_sc_hd__mux4_4 _TECHMAP_MUX4 (
+  sky130_fd_sc_hd__mux4_1 _TECHMAP_MUX4 (
       .X(Y),
       .A0(A),
       .A1(B),

--- a/sky130/openlane/sky130_fd_sc_hd/no_synth.cells
+++ b/sky130/openlane/sky130_fd_sc_hd/no_synth.cells
@@ -70,8 +70,6 @@ sky130_fd_sc_hd__maj3_4
 sky130_fd_sc_hd__mux2i_1
 sky130_fd_sc_hd__mux2i_2
 sky130_fd_sc_hd__mux2i_4
-sky130_fd_sc_hd__probe_p_8
-sky130_fd_sc_hd__probec_p_8
 sky130_fd_sc_hd__sdfbbn_1
 sky130_fd_sc_hd__sdfbbn_2
 sky130_fd_sc_hd__sdfbbp_1

--- a/sky130/openlane/sky130_fd_sc_hdll/drc_exclude.cells
+++ b/sky130/openlane/sky130_fd_sc_hdll/drc_exclude.cells
@@ -44,6 +44,8 @@ sky130_fd_sc_hdll__muxb16to1_4
 sky130_fd_sc_hdll__o21ai_0
 sky130_fd_sc_hdll__o311ai_0
 sky130_fd_sc_hdll__or2_0
+sky130_fd_sc_hdll__probe_p_8
+sky130_fd_sc_hdll__probec_p_8
 sky130_fd_sc_hdll__xor3_1
 sky130_fd_sc_hdll__xor3_2
 sky130_fd_sc_hdll__xor3_4

--- a/sky130/openlane/sky130_fd_sc_hdll/mux2_map.v
+++ b/sky130/openlane/sky130_fd_sc_hdll/mux2_map.v
@@ -4,7 +4,7 @@ module \$_MUX_ (
     input B,
     input S
     );
-  sky130_fd_sc_hdll__mux2_4 _TECHMAP_MUX (
+  sky130_fd_sc_hdll__mux2_1 _TECHMAP_MUX (
       .X(Y),
       .A0(A),
       .A1(B),

--- a/sky130/openlane/sky130_fd_sc_hdll/no_synth.cells
+++ b/sky130/openlane/sky130_fd_sc_hdll/no_synth.cells
@@ -73,8 +73,6 @@ sky130_fd_sc_hdll__maj3_4
 sky130_fd_sc_hdll__mux2i_1
 sky130_fd_sc_hdll__mux2i_2
 sky130_fd_sc_hdll__mux2i_4
-sky130_fd_sc_hdll__probe_p_8
-sky130_fd_sc_hdll__probec_p_8
 sky130_fd_sc_hdll__sdfbbn_1
 sky130_fd_sc_hdll__sdfbbn_2
 sky130_fd_sc_hdll__sdfbbp_1

--- a/sky130/openlane/sky130_fd_sc_hs/mux2_map.v
+++ b/sky130/openlane/sky130_fd_sc_hs/mux2_map.v
@@ -4,7 +4,7 @@ module \$_MUX_ (
     input B,
     input S
     );
-  sky130_fd_sc_hs__mux2_4 _TECHMAP_MUX (
+  sky130_fd_sc_hs__mux2_1 _TECHMAP_MUX (
       .X(Y),
       .A0(A),
       .A1(B),

--- a/sky130/openlane/sky130_fd_sc_hs/mux4_map.v
+++ b/sky130/openlane/sky130_fd_sc_hs/mux4_map.v
@@ -7,7 +7,7 @@ module \$_MUX4_ (
     input S,
     input T
     );
-  sky130_fd_sc_hs__mux4_4 _TECHMAP_MUX4 (
+  sky130_fd_sc_hs__mux4_1 _TECHMAP_MUX4 (
       .X(Y),
       .A0(A),
       .A1(B),

--- a/sky130/openlane/sky130_fd_sc_ls/mux2_map.v
+++ b/sky130/openlane/sky130_fd_sc_ls/mux2_map.v
@@ -4,7 +4,7 @@ module \$_MUX_ (
     input B,
     input S
     );
-  sky130_fd_sc_ls__mux2_4 _TECHMAP_MUX (
+  sky130_fd_sc_ls__mux2_1 _TECHMAP_MUX (
       .X(Y),
       .A0(A),
       .A1(B),

--- a/sky130/openlane/sky130_fd_sc_ls/mux4_map.v
+++ b/sky130/openlane/sky130_fd_sc_ls/mux4_map.v
@@ -7,7 +7,7 @@ module \$_MUX4_ (
     input S,
     input T
     );
-  sky130_fd_sc_ls__mux4_4 _TECHMAP_MUX4 (
+  sky130_fd_sc_ls__mux4_1 _TECHMAP_MUX4 (
       .X(Y),
       .A0(A),
       .A1(B),

--- a/sky130/openlane/sky130_fd_sc_ms/mux2_map.v
+++ b/sky130/openlane/sky130_fd_sc_ms/mux2_map.v
@@ -4,7 +4,7 @@ module \$_MUX_ (
     input B,
     input S
     );
-  sky130_fd_sc_ms__mux2_4 _TECHMAP_MUX (
+  sky130_fd_sc_ms__mux2_1 _TECHMAP_MUX (
       .X(Y),
       .A0(A),
       .A1(B),

--- a/sky130/openlane/sky130_fd_sc_ms/mux4_map.v
+++ b/sky130/openlane/sky130_fd_sc_ms/mux4_map.v
@@ -7,7 +7,7 @@ module \$_MUX4_ (
     input S,
     input T
     );
-  sky130_fd_sc_ms__mux4_4 _TECHMAP_MUX4 (
+  sky130_fd_sc_ms__mux4_1 _TECHMAP_MUX4 (
       .X(Y),
       .A0(A),
       .A1(B),


### PR DESCRIPTION
-  Map to the smallest mux by default, since resizer always resizes them to the smallest size anyways + mux4_4 makes the latest tritonRoute unhappy, so let's use this as an until-then solution.
- move all probe/c cells to the drc_exclude list
