### PR TITLE
Added import button to project manager

### DIFF
--- a/common/treeviewchoice.py
+++ b/common/treeviewchoice.py
@@ -95,8 +95,9 @@ class TreeViewChoice(ttk.Frame):
                 pass
         if self.selectcallback:
             self.selectcallback(value)
-        self.lastselected = selection
-        self.lasttag = oldtag
+        if (selection!=self.lastselected):
+            self.lastselected = selection
+            self.lasttag = oldtag
     
     #Populate the project view
     def repopulate(self, itemlist=[], versioning=False):
@@ -154,7 +155,6 @@ class TreeViewChoice(ttk.Frame):
             while self.treeView.exists(name):
                 n += 1
                 name = origname + '(' + str(n) + ')'
-            mode = 'even' if mode == 'odd' else 'odd'
             # Note: iid value with spaces in it is a bad idea.
             if ' ' in name:
                 name = name.replace(' ', '_')
@@ -162,8 +162,12 @@ class TreeViewChoice(ttk.Frame):
             # optionally: Mark directories with trailing slash
             if self.markDir and os.path.isdir(item):
                 origname += "/"
-                
-            self.treeView.insert('', 'end', text=origname, iid=item, value=item, tag=mode)
+            
+            if ('subcells' not in item):
+                mode = 'even' if mode == 'odd' else 'odd'
+                self.treeView.insert('', 'end', text=origname, iid=item, value=item, tag=mode)
+            else:
+                self.treeView.insert('', 'end', text=origname, iid=item, value=item, tag='odd')
             
             if 'subcells' in os.path.split(item)[0]:
             # If a project is a subproject, move it under its parent
@@ -174,17 +178,21 @@ class TreeViewChoice(ttk.Frame):
             else:
             # If its not a subproject, create a "subproject" of itself
             # iid shouldn't be repeated since it starts with '.'
-                self.treeView.insert('', 'end', text=origname, iid='.'+item, value=item, tag=mode)
+                self.treeView.insert('', 'end', text=origname, iid='.'+item, value=item, tag='odd')
                 self.treeView.move('.'+item,item,0)
                 m=1
-                        
+        
+                       
         if self.initSelected and self.treeView.exists(self.initSelected):
             if 'subcells' in self.initSelected:
-                parent_path = os.path.split(os.path.split(self.initSelected)[0])[0]
+                parent_path = os.path.split(os.path.split(self.initSelected)[0])[0]               
                 self.setselect(parent_path)
+            elif self.initSelected[0]=='.':
+                self.setselect(self.initSelected[1:])
             else:
                 self.setselect(self.initSelected)
             self.initSelected = None
+        
 
         for button in self.func_buttons:
             button[0].pack_forget()

--- a/common/treeviewchoice.py
+++ b/common/treeviewchoice.py
@@ -162,6 +162,8 @@ class TreeViewChoice(ttk.Frame):
             # optionally: Mark directories with trailing slash
             if self.markDir and os.path.isdir(item):
                 origname += "/"
+            if os.path.islink(item):
+                origname += " (link)"
             
             if ('subcells' not in item):
                 mode = 'even' if mode == 'odd' else 'odd'
@@ -225,19 +227,26 @@ class TreeViewChoice(ttk.Frame):
     # though, or else tuples will have to be generated differently.
 
     def populate2(self, title, itemlist=[], valuelist=[]):
-        # Populate another column
+        # Populate the pdk column
         self.treeView.heading(1, text = title)
         self.treeView.column(1, anchor='center')
         children=list(self.getlist()) 
         
         # Add id's of subprojects
         i=1
-        for c in list(self.getlist()):
-            grandchildren=self.treeView.get_children(item=c)
+        def add_ids(grandchildren):
+            # Recursively add id's of all descendants to the list
+            nonlocal i
             for g in grandchildren:
                 children.insert(i,g)
                 i+=1
+                descendants=self.treeView.get_children(item=g)
+                add_ids(descendants)
             i+=1
+        
+        for c in list(self.getlist()):
+            grandchildren=self.treeView.get_children(item=c)
+            add_ids(grandchildren)
         
         n = 0
         for item in valuelist:

--- a/common/treeviewchoice.py
+++ b/common/treeviewchoice.py
@@ -187,10 +187,19 @@ class TreeViewChoice(ttk.Frame):
                        
         if self.initSelected and self.treeView.exists(self.initSelected):
             if 'subcells' in self.initSelected:
-                parent_path = os.path.split(os.path.split(self.initSelected)[0])[0]               
-                self.setselect(parent_path)
+                # ancestor projects must be expanded before setting current
+                item_path = self.initSelected
+                ancestors = []
+                while 'subcells' in item_path:
+                    item_path = os.path.split(os.path.split(item_path)[0])[0]
+                    ancestors.insert(0,item_path)
+                for a in ancestors:
+                    self.treeView.item(a, open=True)       
+                self.setselect(self.initSelected)
             elif self.initSelected[0]=='.':
-                self.setselect(self.initSelected[1:])
+                parent_path = self.initSelected[1:]
+                self.treeView.item(parent_path, open=True) 
+                self.setselect(self.initSelected)
             else:
                 self.setselect(self.initSelected)
             self.initSelected = None
@@ -242,11 +251,11 @@ class TreeViewChoice(ttk.Frame):
                 i+=1
                 descendants=self.treeView.get_children(item=g)
                 add_ids(descendants)
-            i+=1
         
         for c in list(self.getlist()):
             grandchildren=self.treeView.get_children(item=c)
             add_ids(grandchildren)
+            i+=1
         
         n = 0
         for item in valuelist:
@@ -260,7 +269,6 @@ class TreeViewChoice(ttk.Frame):
                 valuelist.insert(n,item)
             n += 1
         
-        
     def func_callback(self, callback, event=None):
         callback(self.treeView.item(self.treeView.selection()))
 
@@ -269,7 +277,7 @@ class TreeViewChoice(ttk.Frame):
 
     def setselect(self, value):
         self.treeView.selection_set(value)
-
+        
     def selected(self):
         value = self.treeView.item(self.treeView.selection())
         if value['values']:


### PR DESCRIPTION
Current functionality of import button:

1. Opens up a dialog for user to choose the name of the project and the project/subproject to be imported through a file explorer.
2. Checks the name and makes sure an info.yaml file exists
3. Attempts to find the pdk of the project and creates the symbolic link "techdir" if it doesn't exist.
4. Creates a symbolic link in the design directory/a project's "subcells" directory depending on which project is selected in the treeview

Removed the IP and Import windows in the project manager.

Fixed the alternate shading of projects in the treeview. All subprojects are shaded white.