### PR TITLE
Corrects 3 terminal x-device resistor conversion.

### DIFF
--- a/sky130/custom/scripts/fix_device_models.py
+++ b/sky130/custom/scripts/fix_device_models.py
@@ -32,7 +32,7 @@ def filter(inname, outname):
 
     dioderex = re.compile('.*[ \t]+sky130_fd_pr__diode_pw2nd[ \t]+')
     ndioderex = re.compile('.*[ \t]+ndiode_h[ \t]+')
-    shortrex = re.compile('.*[ \t]+short[ \t]+')
+    shortrex = re.compile('(.*[ \t]+)(\S+)([ \t]+short[ \t]+.*)')
 
     for line in slines:
 
@@ -57,8 +57,9 @@ def filter(inname, outname):
             fixedlines.append(fline)
             modified = True
         elif smatch:
-            fline = re.sub('short', 'sky130_fd_pr__res_generic_po', line)
-            fline = re.sub('^X', 'R', fline)
+            fline = ( re.sub('^X', 'R', smatch.group(1)) 
+                    + re.sub('short', 'sky130_fd_pr__res_generic_po', smatch.group(3)) 
+                    + " $SUB=" + smatch.group(2) )
             fixedlines.append(fline)
             modified = True
         else:


### PR DESCRIPTION
Changes 3rd terminal to $SUB=xxx where xxx is the 3rd terminal.

Should resolve the remaining issues with #59.

For example, the change to `sky130_fd_sc_hd.spice` would be

Before
```
.subckt sky130_fd_sc_hd__conb_1 VGND VNB VPB VPWR HI LO
R0 VGND LO VNB sky130_fd_pr__res_generic_po w=480000u l=45000u
R1 HI VPWR VNB sky130_fd_pr__res_generic_po w=480000u l=45000u
.ends
```

After
```
.subckt sky130_fd_sc_hd__conb_1 VGND VNB VPB VPWR HI LO
R0 VGND LO  sky130_fd_pr__res_generic_po w=480000u l=45000u $SUB=VNB
R1 HI VPWR  sky130_fd_pr__res_generic_po w=480000u l=45000u $SUB=VNB
.ends
```

Unfortunately, this results in the following LVS property errors. These can be ignored via a netgen setup change which I'll submit later.
```
There were property errors.
sky130_fd_pr__res_generic_po1 vs. sky130_fd_pr__res_generic_po0:
Property $SUB in circuit2 has no matching property in circuit1
sky130_fd_pr__res_generic_po0 vs. sky130_fd_pr__res_generic_po1:
Property $SUB in circuit2 has no matching property in circuit1
```