### PR TITLE
Remove buf_1 from the cts buffer list

### DIFF
--- a/sky130/openlane/sky130_fd_sc_hd/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hd/config.tcl
@@ -64,7 +64,7 @@ set ::env(ROOT_CLK_BUFFER) sky130_fd_sc_hd__clkbuf_16
 set ::env(CLK_BUFFER) sky130_fd_sc_hd__clkbuf_4
 set ::env(CLK_BUFFER_INPUT) A
 set ::env(CLK_BUFFER_OUTPUT) X
-set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hd__clkbuf_1 sky130_fd_sc_hd__clkbuf_2 sky130_fd_sc_hd__clkbuf_4 sky130_fd_sc_hd__clkbuf_8"
+set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hd__clkbuf_2 sky130_fd_sc_hd__clkbuf_4 sky130_fd_sc_hd__clkbuf_8"
 set ::env(FP_PDN_RAIL_WIDTH) 0.48
 # Determined from https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hd/blob/ac7fb61f06e6470b94e8afdf7c25268f62fbd7b1/cells/clkbuf/sky130_fd_sc_hd__clkbuf_16__tt_025C_1v80.lib.json
 set ::env(CTS_MAX_CAP) 1.53169

--- a/sky130/openlane/sky130_fd_sc_hdll/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hdll/config.tcl
@@ -61,7 +61,7 @@ set ::env(ROOT_CLK_BUFFER) $::env(STD_CELL_LIBRARY)__clkbuf_16
 set ::env(CLK_BUFFER) $::env(STD_CELL_LIBRARY)__clkbuf_4
 set ::env(CLK_BUFFER_INPUT) A
 set ::env(CLK_BUFFER_OUTPUT) X
-set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hdll__clkbuf_1 sky130_fd_sc_hdll__clkbuf_2 sky130_fd_sc_hdll__clkbuf_4 sky130_fd_sc_hdll__clkbuf_8"
+set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hdll__clkbuf_2 sky130_fd_sc_hdll__clkbuf_4 sky130_fd_sc_hdll__clkbuf_8"
 set ::env(FP_PDN_RAIL_WIDTH) 0.48
 # Determined from https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hdll/blob/0694bd23893de20f5233ef024acf6cca1e750ac6/cells/clkbuf/sky130_fd_sc_hdll__clkbuf_16__tt_025C_1v80.lib.json
 set ::env(CTS_MAX_CAP) 1.03547

--- a/sky130/openlane/sky130_fd_sc_hvl/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hvl/config.tcl
@@ -69,7 +69,7 @@ set ::env(ROOT_CLK_BUFFER) sky130_fd_sc_hvl__buf_16
 set ::env(CLK_BUFFER) sky130_fd_sc_hvl__buf_4
 set ::env(CLK_BUFFER_INPUT) A
 set ::env(CLK_BUFFER_OUTPUT) X
-set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hvl__buf_1 sky130_fd_sc_hvl__buf_2 sky130_fd_sc_hvl__buf_4 sky130_fd_sc_hvl__buf_8"
+set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hvl__buf_2 sky130_fd_sc_hvl__buf_4 sky130_fd_sc_hvl__buf_8"
 set ::env(CTS_MAX_CAP) 5.57100
 set ::env(DEFAULT_MAX_TRAN) 0.75
 set ::env(FP_PDN_RAIL_WIDTH) 0.51

--- a/sky130/openlane/sky130_fd_sc_ls/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ls/config.tcl
@@ -64,7 +64,7 @@ set ::env(ROOT_CLK_BUFFER) $::env(STD_CELL_LIBRARY)__clkbuf_16
 set ::env(CLK_BUFFER) $::env(STD_CELL_LIBRARY)__clkbuf_4
 set ::env(CLK_BUFFER_INPUT) A
 set ::env(CLK_BUFFER_OUTPUT) X
-set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_ls__clkbuf_1 sky130_fd_sc_ls__clkbuf_2 sky130_fd_sc_ls__clkbuf_4 sky130_fd_sc_ls__clkbuf_8"
+set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_ls__clkbuf_2 sky130_fd_sc_ls__clkbuf_4 sky130_fd_sc_ls__clkbuf_8"
 set ::env(CTS_MAX_CAP) 1.53169
 set ::env(DEFAULT_MAX_TRAN) 0.75
 set ::env(FP_PDN_RAIL_WIDTH) 0.48


### PR DESCRIPTION
- clkbuf_1 was causing max slew and max capacitance violations in most of the designs in openlane, so we decided to remove it from the cts buffer list so that the constructed clock tree doesn't have clkbuf_1.