### PR TITLE
Replace SYNTH_DRIVING_CELL with size 2 inverters

### DIFF
--- a/sky130/openlane/sky130_fd_sc_hd/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hd/config.tcl
@@ -30,7 +30,7 @@ set ::env(FP_WELLTAP_CELL) "sky130_fd_sc_hd__tapvpwrvgnd_1"
 set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_hd__decap_3"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hd__inv_1"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hd__inv_2"
 #capacitance : 0.017653;
 set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
 # update these 

--- a/sky130/openlane/sky130_fd_sc_hdll/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hdll/config.tcl
@@ -27,7 +27,7 @@ set ::env(FP_WELLTAP_CELL) "sky130_fd_sc_hdll__tapvpwrvgnd_1"
 set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_hdll__decap_3"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hdll__inv_1"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hdll__inv_2"
 #capacitance : 0.017653;
 set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
 # update these

--- a/sky130/openlane/sky130_fd_sc_hs/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hs/config.tcl
@@ -30,7 +30,7 @@ set ::env(FP_WELLTAP_CELL) "sky130_fd_sc_hs__tapvpwrvgnd_1"
 set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_hs__decap_4"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hs__inv_1"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hs__inv_2"
 #capacitance : 0.02104;
 set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
 # update these

--- a/sky130/openlane/sky130_fd_sc_hvl/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hvl/config.tcl
@@ -36,7 +36,7 @@ set ::env(PLACE_SITE_HEIGHT) 4.070
 set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_hvl__decap_4"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hvl__inv_1"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hvl__inv_2"
 #capacitance : 0.017653;
 set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
 # update these 

--- a/sky130/openlane/sky130_fd_sc_ls/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ls/config.tcl
@@ -30,7 +30,7 @@ set ::env(FP_WELLTAP_CELL) "sky130_fd_sc_ls__tapvpwrvgnd_1"
 set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_ls__decap_4"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_ls__inv_1"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_ls__inv_2"
 #capacitance : 0.017653;
 set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
 # update these

--- a/sky130/openlane/sky130_fd_sc_ms/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ms/config.tcl
@@ -30,7 +30,7 @@ set ::env(FP_WELLTAP_CELL) "sky130_fd_sc_ms__tapvpwrvgnd_1"
 set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_ms__decap_4"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_ms__inv_1"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_ms__inv_2"
 #capacitance : 0.017653;
 set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
 # update these


### PR DESCRIPTION
As it stands, the size 1 inverters are the SYNTH_DRIVING_CELL for all SCLs. Problem is, they're also on the no synth list.

See https://github.com/The-OpenROAD-Project/OpenLane/issues/692