### PR TITLE
Use `pipefail` so make sees command failures.

### DIFF
--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -129,7 +129,12 @@
 #
 #--------------------------------------------------------------------
 # This Makefile contains bash-isms
-SHELL = bash
+SHELL := /bin/bash
+export SHELL
+# We use pipes to save output to files, without pipefail they will always be
+# seen by make as having succeeded.
+SHELLOPTS := pipefail
+export SHELLOPTS
 MV = mv
 SED = @SED@
 


### PR DESCRIPTION
In a pipeline, normally only the exit code of the last command matters.
Thus when sending stuff through tee, a failure of the first command is lost. `pipefail` makes sure that a failure on the first command causes a failure exit code.

More info at
https://stackoverflow.com/questions/6871859/piping-command-output-to-tee-but-also-save-exit-code-of-command

Fixes #180 - "foundry_install.py script failing doesn't stop the build"