### PR TITLE
Error when subprocess command fails in foundry_install script

### DIFF
--- a/common/foundry_install.py
+++ b/common/foundry_install.py
@@ -250,10 +250,21 @@ def subprocess_run(name, cmd, stdin=subprocess.DEVNULL, cwd=None):
             print(line)
 
     if fproc.returncode != 0:
-        emsg = "Command {} failed with exit code: {}\n".format(
-            name, fproc.returncode)
-        emsg += "  " + " ".join(cmd)
-        raise SystemError(emsg)
+        emsg = [
+            "Command {} failed with exit code: {}\n".format(
+                name, fproc.returncode),
+            "  " + " ".join(cmd),
+        ]
+        if stdin != subprocess.DEVNULL:
+            stdin.seek(0)
+            input_script = stdin.read()
+            emsg += [
+                "\nInput script was:\n",
+                '-'*75,'\n',
+                input_script,'\n',
+                '-'*75,'\n',
+            ]
+        raise SystemError("".join(emsg))
 
 #----------------------------------------------------------------------------
 #----------------------------------------------------------------------------

--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -129,7 +129,12 @@
 #
 #--------------------------------------------------------------------
 # This Makefile contains bash-isms
-SHELL = bash
+SHELL := /bin/bash
+export SHELL
+# We use pipes to save output to files, without pipefail they will always be
+# seen by make as having succeeded.
+SHELLOPTS := pipefail
+export SHELLOPTS
 MV = mv
 SED = @SED@
 


### PR DESCRIPTION
Refactor the subprocess calls in the `common/foundry_install.py` script so that if a call to a sub-command fails (such as magic segfaulting shown in #183) the whole script will fail. 

When combined with #186, the build process will now terminate if the magic or other sub-command errors.

See example @ https://github.com/mithro/open_pdks/runs/4304473902?check_suite_focus=true and below;
```
Error while reading cell "sky130_ef_sc_hd__fill_12" (byte position 372): Cell "sky130_fd_sc_hd__decap_6" is used but not defined in this file.
Error while reading cell "sky130_ef_sc_hd__fill_12" (byte position 372): cell sky130_fd_sc_hd__decap_6 was used but not defined.
Error while reading cell "sky130_ef_sc_hd__fill_12" (byte position 372): cell sky130_fd_sc_hd__fill_2 was used but not defined.
Error while reading cell "sky130_ef_sc_hd__fill_12" (byte position 372): cell sky130_fd_sc_hd__fill_4 was used but not defined.
File sky130_fd_sc_hd__decap_6 contained format error
"sky130_fd_sc_hd__decap_6" has a zero timestamp; it should be written out
    to establish a correct timestamp.
freeMagic called with NULL argument.
Traceback (most recent call last):
  File "../common/foundry_install.py", line 1648, in <module>
    cwd = destlibdir,
  File "../common/foundry_install.py", line 256, in subprocess_run
    raise SystemError(emsg)
SystemError: Command magic failed with exit code: -11
  magic -dnull -noconsole
make[3]: *** [Makefile:1048: digital-hd-a] Error 1
make[2]: *** [Makefile:856: vendor-a] Error 2
make[1]: *** [Makefile:583: all-a] Error 2
make[3]: Leaving directory '/home/runner/work/open_pdks/open_pdks/sky130'
make[2]: Leaving directory '/home/runner/work/open_pdks/open_pdks/sky130'
make[1]: Leaving directory '/home/runner/work/open_pdks/open_pdks/sky130'
make: *** [Makefile:58: build-pdk] Error 2
Error: Process completed with exit code 2.
```