### PR TITLE
Add capturing of CI artifacts

### DIFF
--- a/.github/build-docker.sh
+++ b/.github/build-docker.sh
@@ -16,3 +16,8 @@
 set -e
 
 docker build --rm -t magic .
+
+# Copy the build.tar.gz out of the docker container
+docker run --name magic magic:latest
+docker cp magic:/build.tar.gz ./magic.tar.gz
+docker rm magic

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -19,9 +19,21 @@ if ! [[ -d $SKY130_DIR ]]; then
     exit -1
 fi
 
+mkdir -p ${GITHUB_WORKSPACE}/output/
+
+# Copy build log.
+cp ./sky130/sky130A_install.log ${GITHUB_WORKSPACE}/output/
+
+# Copy any core dupmps into the output directory.
+find -name core -not \( -path */skywater-pdk/* -prune \) | \
+	awk -v ln=1 '{print "cp " $0 " ${GITHUB_WORKSPACE}/output/core." ln++ }' | \
+	bash
+
+# Copy the magic tarball into output
+cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
+
 # Try to create a deterministic tar file
 # https://reproducible-builds.org/docs/archives/
-mkdir ${GITHUB_WORKSPACE}/output/
 (
 	cd ${SKY130_DIR}
 	tar \

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -19,7 +19,7 @@ mkdir -p ${GITHUB_WORKSPACE}/output/
 cp ./sky130/sky130A_install.log ${GITHUB_WORKSPACE}/output/
 
 # Copy any core dupmps into the output directory.
-find -name core -not \( -path */skywater-pdk/* -prune \) | \
+find . -name core -not \( -path */skywater-pdk/* -prune \) | \
 	awk -v ln=1 '{print "cp " $0 " ${GITHUB_WORKSPACE}/output/core." ln++ }' | \
 	bash
 

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -35,6 +35,8 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 	    exit -1
 	fi
 
+	echo ::group::PDK tarball
+
 	cd ${SKY130_DIR}
 	tar \
 		--create \
@@ -49,6 +51,8 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 		--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
 		\
 		--file ${GITHUB_WORKSPACE}/output/pdk-SKY130A-${STD_CELL_LIBRARY}.tar.xz .
+
+	echo ::endgroup::
 )
 
 echo ::group::Output files

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -19,7 +19,7 @@ mkdir -p ${GITHUB_WORKSPACE}/output/
 cp ./sky130/sky130A_install.log ${GITHUB_WORKSPACE}/output/
 
 # Copy any core dupmps into the output directory.
-find . -name core -not \( -path */skywater-pdk/* -prune \) | \
+find . -name core -not \( -path '*/skywater-pdk/*' -prune \) | \
 	awk -v ln=1 '{print "cp " $0 " ${GITHUB_WORKSPACE}/output/core." ln++ }' | \
 	bash
 

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -13,12 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SKY130_DIR="$(pwd)/pdks/pdk/sky130A"
-if ! [[ -d $SKY130_DIR ]]; then
-    echo "Missing $SKY130_DIR"
-    exit -1
-fi
-
 mkdir -p ${GITHUB_WORKSPACE}/output/
 
 # Copy build log.
@@ -35,6 +29,12 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 # Try to create a deterministic tar file
 # https://reproducible-builds.org/docs/archives/
 (
+	SKY130_DIR="$(pwd)/pdks/pdk/sky130A"
+	if ! [[ -d $SKY130_DIR ]]; then
+	    echo "Missing $SKY130_DIR"
+	    exit -1
+	fi
+
 	cd ${SKY130_DIR}
 	tar \
 		--create \

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2021 Open PDKs Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SKY130_DIR="$(pwd)/pdks/pdk/sky130A"
+if ! [[ -d $SKY130_DIR ]]; then
+    echo "Missing $SKY130_DIR"
+    exit -1
+fi
+
+# Try to create a deterministic tar file
+# https://reproducible-builds.org/docs/archives/
+mkdir ${GITHUB_WORKSPACE}/output/
+(
+	cd ${SKY130_DIR}
+	tar \
+		--create \
+		--xz \
+		--verbose \
+		\
+		--mtime='2020-05-07 00:00Z' \
+		--sort=name \
+		--owner=0 \
+		--group=0 \
+		--numeric-owner \
+		--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+		\
+		--file ${GITHUB_WORKSPACE}/output/pdk-SKY130A-${STD_CELL_LIBRARY}.tar.xz .
+)

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -50,3 +50,9 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 		\
 		--file ${GITHUB_WORKSPACE}/output/pdk-SKY130A-${STD_CELL_LIBRARY}.tar.xz .
 )
+
+echo ::group::Output files
+find  ${GITHUB_WORKSPACE}/output/
+echo ::endgroup::
+
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,15 @@ jobs:
     - name: Test
       run: |
         bash .github/test.sh
+
+    - name: Capture
+      if: ${{ always() }}
+      run: |
+        bash .github/capture.sh
+
+    - name: Upload
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.library }}
+        path: ${{ github.workspace }}/output/**


### PR DESCRIPTION
Fixes #191.

Captures the built PDK, magic, any core dumps and uploads them at GitHub Action artifacts.

Example at https://github.com/mithro/open_pdks/actions/runs/1497739535

![Screenshot from 2021-11-23 21-41-54](https://user-images.githubusercontent.com/21212/143181478-6edd982b-6d6c-47bc-9854-d7c86a87204e.png)

