### PR TITLE
Improve the CI run times by using less aggressive compression settings

### DIFF
--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -40,7 +40,7 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 	cd ${SKY130_DIR}
 	tar \
 		--create \
-		--xz \
+		--gzip \
 		--verbose \
 		\
 		--mtime='2020-05-07 00:00Z' \
@@ -50,7 +50,7 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 		--numeric-owner \
 		--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
 		\
-		--file ${GITHUB_WORKSPACE}/output/pdk-SKY130A-${STD_CELL_LIBRARY}.tar.xz .
+		--file ${GITHUB_WORKSPACE}/output/pdk-SKY130A-${STD_CELL_LIBRARY}.tar.gz .
 
 	echo ::endgroup::
 )

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -52,12 +52,29 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 		\
 		--file ${GITHUB_WORKSPACE}/output/pdk-SKY130A-${STD_CELL_LIBRARY}.tar.bz2 .
 
-	# Remove the stuff we just put in the tarball so we don't run out of disk space.
-	rm -rf .
-
 	echo ::endgroup::
 )
 
+# Free up disk space so the GitHub Action runner doesn't die when collecting
+# the artifacts.
+echo ::group::Freeup space
+
+df -h
+
+for DIR in ${GITHUB_WORKSPACE}/*; do
+	if [ x$DIR = x"${GITHUB_WORKSPACE}/output" ]; then
+		continue
+	fi
+	echo
+	echo "Removing $DIR"
+	rm -rvf $DIR
+done
+
+df -h
+
+echo ::endgroup::
+
+# Output which files are being saved.
 echo ::group::Output files
 du -h  ${GITHUB_WORKSPACE}/output/*
 echo ::endgroup::

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -56,7 +56,7 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 )
 
 echo ::group::Output files
-find  ${GITHUB_WORKSPACE}/output/
+du -h  ${GITHUB_WORKSPACE}/output/*
 echo ::endgroup::
 
 exit 0

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -40,7 +40,7 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 	cd ${SKY130_DIR}
 	tar \
 		--create \
-		--gzip \
+		--bzip2 \
 		--verbose \
 		\
 		--mtime='2020-05-07 00:00Z' \
@@ -50,7 +50,7 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 		--numeric-owner \
 		--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
 		\
-		--file ${GITHUB_WORKSPACE}/output/pdk-SKY130A-${STD_CELL_LIBRARY}.tar.gz .
+		--file ${GITHUB_WORKSPACE}/output/pdk-SKY130A-${STD_CELL_LIBRARY}.tar.bz2 .
 
 	echo ::endgroup::
 )

--- a/.github/capture.sh
+++ b/.github/capture.sh
@@ -52,6 +52,9 @@ cp .github/magic.tar.gz ${GITHUB_WORKSPACE}/output/
 		\
 		--file ${GITHUB_WORKSPACE}/output/pdk-SKY130A-${STD_CELL_LIBRARY}.tar.bz2 .
 
+	# Remove the stuff we just put in the tarball so we don't run out of disk space.
+	rm -rf .
+
 	echo ::endgroup::
 )
 


### PR DESCRIPTION
The `Run (all)` job previously took ~90 minutes, it now takes ~45 minutes. Most of the other jobs also reduce by 50% too. This fixes #193 .

The negative is that it doubles the output artifact size.

| Before | **After** |
| --------- | ------ |
| ![Screenshot from 2021-11-28 09-57-35](https://user-images.githubusercontent.com/21212/143800336-fb2a5508-5c6f-4433-99ee-3d03a2c2606e.png) | ![Screenshot from 2021-11-28 18-45-08](https://user-images.githubusercontent.com/21212/143800666-40e91b3c-a42f-4af3-9659-af7bfbb45f04.png) |
| --------- | ------ |
| ![Screenshot from 2021-11-28 18-46-39](https://user-images.githubusercontent.com/21212/143800797-446a77e3-473a-4154-9ad3-6a894dba902d.png) | ![Screenshot from 2021-11-28 18-46-46](https://user-images.githubusercontent.com/21212/143800816-3107f621-2056-48d5-b90d-597241fc0e31.png) |


