### PR TITLE
Changes for sky130_sram macros.

### DIFF
--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -1329,7 +1329,7 @@ sram-a:
 		-lef %l/*/*.lef \
 		-lib %l/*/*.lib \
 		-gds %l/*/*.gds options=custom/scripts/gds_import_sram.tcl \
-		-spice %l/*/*[0-9].sp filter=custom/scripts/sp_to_spice.py \
+		-spice %l/*/*.lvs.sp filter=custom/scripts/sp_to_spice.py \
 		-verilog %l/*/*.v \
 		-library general sky130_sram_macros 2>&1 | tee -a ${SKY130A}_make.log
 


### PR DESCRIPTION
Changed sram spice source from `*.sp` to `*.lvs.sp` because `*.sp` doesn’t have the correct memory cell parasitic devices.
Changed `l` and `w` units from meters to micrometers.
Reversed bus order in sram top subckt pins.

The base code for creating the new file (error handling, etc.) was taken from other scripts in the same directory. Parameter scaling and bus reordering was added.
Error handling has not been tested.
Successfully passed LVS with the `mgmt_core` module from `https://github.com/efabless/caravel_mgmt_soc_litex.git` which contains `sky130_sram_2kbyte_1rw1r_32x512_8`.

These changes should be all that are needed to allow the `sky130_sram` macros to pass device level LVS (although the current version of netgen does take awhile).