### PR TITLE
Updated /sky130/readme to include reram library path

### DIFF
--- a/sky130/README
+++ b/sky130/README
@@ -102,11 +102,12 @@ Prerequisites:
 	git submodule init libraries/sky130_fd_pr/latest
 	git submodule init libraries/sky130_fd_sc_hd/latest
 	git submodule init libraries/sky130_fd_sc_hvl/latest
+	[git submodule init libraries/sky130_fd_pr_reram/latest]
 	[git submodule init libraries/sky130_fd_sc_hdll/latest]
 	[git submodule init libraries/sky130_fd_sc_hs/latest]
 	[git submodule init libraries/sky130_fd_sc_ms/latest]
-	[git submodule init libraries/sky130_fd_sc_ls/latest]
 	[git submodule init libraries/sky130_fd_sc_lp/latest]
+	[git submodule init libraries/sky130_fd_sc_ls/latest]
 	git submodule update
 
     The liberty (.lib) files are the largest of all and so individual files


### PR DESCRIPTION
Added reram path as an optional git submodule for completeness. Might need corresponding update to the documentation on http://www.opencircuitdesign.com/open_pdks/