### PR TITLE
Fix default_fanout_load

### DIFF
--- a/common/foundry_install.py
+++ b/common/foundry_install.py
@@ -648,7 +648,6 @@ if __name__ == '__main__':
                 for item in option:
                     if item.split('=')[0] == 'filter':
                         filter_scripts.append(item.split('=')[1])
-                        break
 
                 if ef_format:
                     techlefdir = targetdir + '/libs.ref/' + 'techLEF'
@@ -685,7 +684,6 @@ if __name__ == '__main__':
                 for item in option:
                     if item.split('=')[0] == 'filter':
                         filter_scripts.append(item.split('=')[1])
-                        break
 
                 print('Diagnostic:  installing to ' + option[0] + '.')
                 tooldir = targetdir + '/libs.tech/' + option[0]
@@ -813,7 +811,6 @@ if __name__ == '__main__':
         for item in option:
             if item.split('=')[0] == 'filter':
                 filter_scripts.append(item.split('=')[1])
-                break
 
         # Option 'stub' applies to netlists ('cdl' or 'spice') and generates
         # a file with only stub entries.

--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -1248,6 +1248,7 @@ digital-hd-%:
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
 		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
+			filter=custom/scripts/fix_default_fanout_load.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			no-copy=custom/sky130_fd_sc_hd/gds/sky130_fd*.gds \
 			include=custom/sky130_fd_sc_hd/gds/sky130_ef*.gds \
@@ -1302,6 +1303,7 @@ digital-hdll-%:
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
 		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
+			filter=custom/scripts/fix_default_fanout_load.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			options=custom/scripts/gds_import_setup.tcl \
 			sort=../common/sort_pdkfiles.py \
@@ -1341,6 +1343,7 @@ digital-hvl-%:
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
 		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
+			filter=custom/scripts/fix_default_fanout_load.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			include=custom/sky130_fd_sc_hvl/gds/sky130_ef*.gds \
 			options=custom/scripts/gds_import_setup.tcl \
@@ -1387,6 +1390,7 @@ digital-lp-%:
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
 		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
+			filter=custom/scripts/fix_default_fanout_load.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			options=custom/scripts/gds_import_setup.tcl \
 			sort=../common/sort_pdkfiles.py \
@@ -1425,6 +1429,7 @@ digital-hs-%:
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
 		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
+			filter=custom/scripts/fix_default_fanout_load.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			no-copy=custom/sky130_fd_sc_hs/gds/sky130_fd*.gds \
 			options=custom/scripts/gds_import_setup.tcl \
@@ -1460,6 +1465,7 @@ digital-ms-%:
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
 		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
+			filter=custom/scripts/fix_default_fanout_load.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			options=custom/scripts/gds_import_setup.tcl \
 			sort=../common/sort_pdkfiles.py \
@@ -1494,6 +1500,7 @@ digital-ls-%:
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
 		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
+			filter=custom/scripts/fix_default_fanout_load.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			options=custom/scripts/gds_import_setup.tcl \
 			sort=../common/sort_pdkfiles.py \

--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -1301,7 +1301,7 @@ digital-hdll-%:
 			filter=custom/scripts/fix_digital_lef.py \
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
-		-lib %l/latest/timing/*.lib custom/scripts/add_wireloads.py \
+		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			options=custom/scripts/gds_import_setup.tcl \
 			sort=../common/sort_pdkfiles.py \
@@ -1340,7 +1340,7 @@ digital-hvl-%:
 			exclude=*.magic.lef lefopts=-toplayer \
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
-		-lib %l/latest/timing/*.lib custom/scripts/add_wireloads.py \
+		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			include=custom/sky130_fd_sc_hvl/gds/sky130_ef*.gds \
 			options=custom/scripts/gds_import_setup.tcl \
@@ -1386,7 +1386,7 @@ digital-lp-%:
 			filter=custom/scripts/fix_digital_lef.py \
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
-		-lib %l/latest/timing/*.lib custom/scripts/add_wireloads.py \
+		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			options=custom/scripts/gds_import_setup.tcl \
 			sort=../common/sort_pdkfiles.py \
@@ -1424,7 +1424,7 @@ digital-hs-%:
 			filter=custom/scripts/fix_digital_lef.py \
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
-		-lib %l/latest/timing/*.lib custom/scripts/add_wireloads.py \
+		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			no-copy=custom/sky130_fd_sc_hs/gds/sky130_fd*.gds \
 			options=custom/scripts/gds_import_setup.tcl \
@@ -1459,7 +1459,7 @@ digital-ms-%:
 			filter=custom/scripts/fix_digital_lef.py \
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
-		-lib %l/latest/timing/*.lib custom/scripts/add_wireloads.py \
+		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			options=custom/scripts/gds_import_setup.tcl \
 			sort=../common/sort_pdkfiles.py \
@@ -1493,7 +1493,7 @@ digital-ls-%:
 			filter=custom/scripts/fix_digital_lef.py \
 			sort=../common/sort_pdkfiles.py \
 		-doc %l/latest/cells/*/*.pdf \
-		-lib %l/latest/timing/*.lib custom/scripts/add_wireloads.py \
+		-lib %l/latest/timing/*.lib filter=custom/scripts/add_wireloads.py \
 		-gds %l/latest/cells/*/*.gds compile-only \
 			options=custom/scripts/gds_import_setup.tcl \
 			sort=../common/sort_pdkfiles.py \

--- a/sky130/custom/scripts/fix_default_fanout_load.py
+++ b/sky130/custom/scripts/fix_default_fanout_load.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# fix_default_fanout_load.py ---
+#
+# Some of the sky130 liberty files have default_fanout_load set to 1,
+# others have it set to 0. When set to 0 all fan out management and
+# violation reporting is disabled, so change any instances of 0 to 1.
+#
+# This script is a filter to be run by setting the name of this script as
+# the value to "filter=" for the lib install in the sky130 Makefile.
+
+import re
+import os
+import sys
+
+def filter(inname, outname):
+
+    # Read input
+    try:
+        with open(inname, 'r') as inFile:
+            stext = inFile.read()
+            slines = stext.splitlines()
+    except:
+        print('fix_default_fanout_load.py: failed to open ' + inname + ' for reading.', file=sys.stderr)
+        return 1
+
+    # Process input with regexp
+
+    fixedlines = []
+    modified = False
+
+    fanout_re = re.compile('\s*default_fanout_load\s*:\s*([\d\.]+)\s*;')
+
+    for line in slines:
+        lmatch = fanout_re.match(line)
+        if lmatch:
+            val_str = lmatch.group(1)
+            val = int(float(val_str))
+            if val == 0:
+                modified = True
+                line = line.replace(val_str, '1.0000000000')
+
+        fixedlines.append(line)
+
+    # Write output
+    if outname == None:
+        for i in fixedlines:
+            print(i)
+    else:
+        # If the output is a symbolic link but no modifications have been made,
+        # then leave it alone.  If it was modified, then remove the symbolic
+        # link before writing.
+        if os.path.islink(outname):
+            if not modified:
+                return 0
+            else:
+                os.unlink(outname)
+        try:
+            with open(outname, 'w') as outFile:
+                for i in fixedlines:
+                    print(i, file=outFile)
+        except:
+            print('fix_default_fanout_load.py: failed to open ' + outname + ' for writing.', file=sys.stderr)
+            return 1
+
+
+if __name__ == '__main__':
+
+    # This script expects to get one or two arguments.  One argument is
+    # mandatory and is the input file.  The other argument is optional and
+    # is the output file.  The output file and input file may be the same
+    # name, in which case the original input is overwritten.
+
+    options = []
+    arguments = []
+    for item in sys.argv[1:]:
+        if item.find('-', 0) == 0:
+            options.append(item[1:])
+        else:
+            arguments.append(item)
+
+    if len(arguments) > 0:
+        infilename = arguments[0]
+
+    if len(arguments) > 1:
+        outfilename = arguments[1]
+    else:
+        outfilename = None
+
+    result = filter(infilename, outfilename)
+    sys.exit(result)


### PR DESCRIPTION
Some of the sky130 liberty files have default_fanout_load set to 1,
others have it set to 0. When set to 0 all fan out management and
violation reporting is disabled, so change any instances of 0 to 1.