### PR TITLE
sky130B missing THICKNESS LEF props, breaking antenna repair

### DIFF
--- a/common/staging_install.py
+++ b/common/staging_install.py
@@ -204,7 +204,7 @@ def replace_with_symlinks(libfiles, sourcelist):
                     newlibfiles = glob.glob(libfile + '/*')
                     newsourcelist = glob.glob(sourcefile + '/*')
                     total += replace_with_symlinks(newlibfiles, newsourcelist)
-                elif filecmp.cmp(libfile, sourcefile):
+                elif filecmp.cmp(libfile, sourcefile, shallow=False):
                     if not os.path.split(libfile)[1] in exclude:
                         os.remove(libfile)
                         # Use absolute path for the source file
@@ -251,7 +251,7 @@ def replace_all_with_symlinks(libdir, srclibdir, checklibdir):
                     total += replace_all_with_symlinks(libpath, srcpath, checkpath)
             else:
                 try:
-                    if filecmp.cmp(libpath, checkpath):
+                    if filecmp.cmp(libpath, checkpath, shallow=False):
                         os.remove(libpath)
                         os.symlink(srcpath, libpath)
                         total += 1

--- a/sky130/custom/scripts/fix_techlefB.py
+++ b/sky130/custom/scripts/fix_techlefB.py
@@ -95,6 +95,7 @@ def filter(inname, outname):
             fixedlines.append(line)
             curlayer = lmatch.group(1)
         elif tmatch:
+            fixedlines.append(line)
             thickness_seen = True
         else:
             ematch = edgerex.match(line)


### PR DESCRIPTION
On a recent tape out of Microwatt I noticed an absence of any
antenna diodes as well as no antenna violations reported at the signoff
step.

It turns out we are stripping the THICKNESS properties from the sky130B
tech LEF, meaning all side area calculations come out as zero.

While fixing this, I also noticed filecmp.cmp only checks stat values
by default. It incorrectly determines that the sky130A and sky130B tech
LEFs are identical because the sizes and timestamps match, and creates
a symlink. Use shallow=False to force an actual comparison of the
contents.