### PR TITLE
openlane(gf180): update config file

### DIFF
--- a/gf180mcu/openlane/config.tcl
+++ b/gf180mcu/openlane/config.tcl
@@ -78,8 +78,9 @@ set ::env(FP_TAPCELL_DIST) 20
 
 ## Extra PDN configs
 
-### OpenROAD Bug
-set ::env(FP_PDN_IRDROP) 0
+### OpenROAD/tlef Bug
+## via resistance are missing from the tlef causing irdrop to fai
+set ::env(RUN_IRDROP_REPORT) 0
 
 set ::env(FP_PDN_RAIL_OFFSET) 0
 set ::env(FP_PDN_VWIDTH) 1.6
@@ -102,8 +103,9 @@ set ::env(RCX_RULES_MAX) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/rules.
 
 # Routing
 set ::env(METAL_LAYER_NAMES) "Metal1 Metal2 Metal3 Metal4 Metal5"
-set ::env(RT_MIN_LAYER) "Metal1"
+set ::env(RT_MIN_LAYER) "Metal2"
 set ::env(RT_MAX_LAYER) "Metal5"
+set ::env(DRT_MIN_LAYER) "Metal1"
 set ::env(GRT_LAYER_ADJUSTMENTS) "0,0,0,0,0"
 
 ## Tracks info

--- a/gf180mcu/openlane/gf180mcu_fd_sc_mcu7t5v0/config.tcl
+++ b/gf180mcu/openlane/gf180mcu_fd_sc_mcu7t5v0/config.tcl
@@ -36,7 +36,6 @@ set ::env(DIODE_CELL) "$::env(STD_CELL_LIBRARY)__antenna"
 set ::env(DIODE_CELL_PIN) "I"
 set ::env(DIODE_INSERTION_STRATEGY) {4}
 
-set ::env(CELL_PAD) 2
 set ::env(CELL_PAD_EXCLUDE) "$::env(STD_CELL_LIBRARY)__filltie_* $::env(STD_CELL_LIBRARY)__filldecap_* $::env(STD_CELL_LIBRARY)__fill_* $::env(STD_CELL_LIBRARY)__endcap_*"
 
 # TritonCTS configurations
@@ -48,4 +47,7 @@ set ::env(FP_PDN_RAIL_WIDTH) 0.6
 
 # The library maximum transition is 8.9ns; setting it to lower value
 set ::env(DEFAULT_MAX_TRAN) 3
+
+set ::env(GPL_CELL_PADDING) {0}
+set ::env(DPL_CELL_PADDING) {2}
 

--- a/gf180mcu/openlane/gf180mcu_fd_sc_mcu7t5v0/config.tcl
+++ b/gf180mcu/openlane/gf180mcu_fd_sc_mcu7t5v0/config.tcl
@@ -2,7 +2,7 @@ set current_folder [file dirname [file normalize [info script]]]
 
 # Placement site for core cells
 # This can be found in the technology lef
-set ::env(PLACE_SITE) "$::env(STD_CELL_LIBRARY)"
+set ::env(PLACE_SITE) "GF018hv5v_mcu_sc7"
 set ::env(PLACE_SITE_WIDTH) 0.56
 set ::env(PLACE_SITE_HEIGHT) 3.92
 


### PR DESCRIPTION
- disable ir drop report 
- update padding variable names
- set min global routing layer to Metal2 to avoid pin access issues at drt
- update PLACE_SITE for GF018hv5v_mcu_sc7 