### PR TITLE
Adjusting default mim cap generator values to create DRC clean caps

### DIFF
--- a/sky130/magic/sky130.tcl
+++ b/sky130/magic/sky130.tcl
@@ -2347,8 +2347,8 @@ proc sky130::sky130_fd_pr__cap_mim_m3_1_draw {parameters} {
 	    cap_spacing		0.5 \
 	    cap_surround	0.2 \
 	    top_surround	0.005 \
-	    end_surround	0.3 \
-	    end_spacing		0.1 \
+	    end_surround	0.1 \
+	    end_spacing		0.3 \
 	    contact_size	0.32 \
 	    metal_surround	0.08 \
     ]

--- a/sky130/magic/sky130.tcl
+++ b/sky130/magic/sky130.tcl
@@ -2344,11 +2344,11 @@ proc sky130::sky130_fd_pr__cap_mim_m3_1_draw {parameters} {
 	    cap_contact_type	mimcc \
 	    bot_type 		m3 \
 	    bot_surround	0.2 \
-	    cap_spacing		0.5 \
+	    cap_spacing		1.2 \
 	    cap_surround	0.2 \
 	    top_surround	0.005 \
 	    end_surround	0.1 \
-	    end_spacing		0.3 \
+	    end_spacing		1.2 \
 	    contact_size	0.32 \
 	    metal_surround	0.08 \
     ]
@@ -2364,7 +2364,7 @@ proc sky130::sky130_fd_pr__cap_mim_m3_2_draw {parameters} {
 	    cap_contact_type	mim2cc \
 	    bot_type 		m4 \
 	    bot_surround	0.4 \
-	    cap_spacing		0.8 \
+	    cap_spacing		1.2 \
 	    cap_surround	0.2 \
 	    top_surround	0.12 \
 	    end_surround	0.1 \

--- a/sky130/magic/sky130.tcl
+++ b/sky130/magic/sky130.tcl
@@ -2343,11 +2343,11 @@ proc sky130::sky130_fd_pr__cap_mim_m3_1_draw {parameters} {
 	    cap_type 		mimcap \
 	    cap_contact_type	mimcc \
 	    bot_type 		m3 \
-	    bot_surround	0.5 \
+	    bot_surround	0.2 \
 	    cap_spacing		0.5 \
 	    cap_surround	0.2 \
 	    top_surround	0.005 \
-	    end_surround	0.1 \
+	    end_surround	0.3 \
 	    end_spacing		0.1 \
 	    contact_size	0.32 \
 	    metal_surround	0.08 \
@@ -2363,16 +2363,16 @@ proc sky130::sky130_fd_pr__cap_mim_m3_2_draw {parameters} {
 	    cap_type 		mimcap2 \
 	    cap_contact_type	mim2cc \
 	    bot_type 		m4 \
-	    bot_surround	0.5 \
-	    cap_spacing		0.5 \
+	    bot_surround	0.4 \
+	    cap_spacing		0.8 \
 	    cap_surround	0.2 \
 	    top_surround	0.12 \
 	    end_surround	0.1 \
-	    end_spacing		0.1 \
+	    end_spacing		2.0 \
 	    contact_size	1.18 \
 	    metal_surround	0.21 \
 	    top_metal_width	1.6 \
-	    top_metal_space	1.7 \
+	    top_metal_space	0.7 \
     ]
     set drawdict [dict merge $sky130::ruleset $newdict $parameters]
     return [sky130::cap_draw $drawdict]


### PR DESCRIPTION
Ref: #293 


Adjusted default mim cap device generator values to create DRC clean capacitors (both Magic with DRC full and Klayout). Please see new screen shots below.

<img width="590" alt="Screen Shot 2022-10-17 at 7 27 25 PM" src="https://user-images.githubusercontent.com/49569515/196309415-0977a26a-8cd1-40fc-9299-31e47de0cd30.png">
<img width="1183" alt="Screen Shot 2022-10-17 at 7 27 05 PM" src="https://user-images.githubusercontent.com/49569515/196309430-7aa0ce80-ec90-41ef-b89a-d016d2ada7b2.png">

