### PR TITLE
bump magic version for gf180mcu

### DIFF
--- a/gf180mcu/gf180mcu.json
+++ b/gf180mcu/gf180mcu.json
@@ -85,7 +85,7 @@
     },
     "reference": {
         "open_pdks": "366a4dab6ec0b670bf6b98587c0a3a8689003ae2",
-        "magic": "01f2ce37b827e79ae37c00e9a42691dade49927b",
+        "magic": "fb091fa03f3646b0f90639a0798b711ca400941d",
         "gf180mcu_pdk": "a897aa30369d3bcec87d9d50ce9b01f320f854ef",
         "gf180mcu_fd_pr": "132dc738056751efdea1cd437c26c45e49862b07",
         "gf180mcu_fd_io": "bcaa40aaf6cf04d6e9cb143d0e5b0de9429e53ab",


### PR DESCRIPTION
I am getting `Error:  Magic version 8.3.348 is required by this techfile, but this version of magic is 8.3.346.` with the current version set in the json file.