### PR TITLE
switch of efabless sky130_klayout_pdk

### DIFF
--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -244,7 +244,7 @@ OSU_T18_PATH = @SKY130_OSU_T18_PATH@
 PDK_URL = https://github.com/google/skywater-pdk
 ALPHA_URL = https://github.com/PaulSchulz/sky130_pschulz_xx_hd
 XSCHEM_URL = https://github.com/StefanSchippers/xschem_sky130
-KLAYOUT_URL = https://github.com/mabrains/sky130_klayout_pdk
+KLAYOUT_URL = https://github.com/efabless/sky130_klayout_pdk
 PRECHECK_URL = https://github.com/efabless/mpw_precheck
 SRAM_URL = https://github.com/efabless/sky130_sram_macros
 SRAM_SPACE_URL = https://foss-eda-tools.googlesource.com/skywater-pdk/libs/sky130_fd_bd_sram
@@ -1009,6 +1009,7 @@ klayout-%: ${KLAYOUT_PATH}
 		cp -rp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/pymacros/* ${KLAYOUT_STAGING_$*}/pymacros/ ; \
 		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lyp ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyp ; \
 		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lyt ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyt ; \
+		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lmp ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lmp ; \
 		cp -rp ${KLAYOUT_PATH}/scripts/* ${KLAYOUT_STAGING_$*}/scripts/ ; \
 	fi
 	# Copy original DRC deck from open_pdks (is this useful?)

--- a/sky130/sky130.json
+++ b/sky130/sky130.json
@@ -104,7 +104,7 @@
         "sky130_fd_bd_sram": "be33adbcf188fdeab5c061699847d9d440f7a084",
         "sky130_ml_xx_hd": "6eb3b0718552b034f1bf1870285ff135e3fb2dcb",
         "xschem_sky130": "5fa1b2e30eda4cdc9949a989d7482531a30b56d4",
-        "klayout_sky130": "7cd7d32bdcbbe32f456a73a02e4653983a6a1850",
+        "klayout_sky130": "dc579b007d27180cbf4085d82e01c732fc34e454",
         "precheck_sky130": "a8a54b74961a43f3a7b85d44843ae2adbc93b233"
     }
 }


### PR DESCRIPTION
mabrains sky130_klayout_pdk is supposed to be for development

- also copy `sky130.lmp` from the sky130 klayout repo (see https://github.com/efabless/sky130_klayout_pdk/pull/2)

- update commit id of sky130_klayout_pdk repo
