### PR TITLE
remove copying ${KLAYOUT_PATH}/scripts

### DIFF
--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -1010,7 +1010,6 @@ klayout-%: ${KLAYOUT_PATH}
 		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lyp ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyp ; \
 		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lyt ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyt ; \
 		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lmp ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lmp ; \
-		cp -rp ${KLAYOUT_PATH}/scripts/* ${KLAYOUT_STAGING_$*}/scripts/ ; \
 	fi
 	# Copy original DRC deck from open_pdks (is this useful?)
 	cp klayout/sky130.lydrc ${KLAYOUT_STAGING_$*}/drc/${SKY130$*}.lydrc


### PR DESCRIPTION
efabless sky130 doesn't have scripts folder