### PR TITLE
Klayout XOR variables

### DIFF
--- a/sky130/openlane/config.tcl
+++ b/sky130/openlane/config.tcl
@@ -90,6 +90,8 @@ set ::env(MAGIC_TECH_FILE) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/magic/TECHNAM
 set ::env(KLAYOUT_TECH) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/$::env(PDK).lyt"
 set ::env(KLAYOUT_PROPERTIES) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/$::env(PDK).lyp"
 set ::env(KLAYOUT_DRC_TECH_SCRIPT) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/drc/$::env(PDK)_mr.drc"
+set ::env(KLAYOUT_DEF_LAYER_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/$::env(PDK).lmp"
+set ::env(KLAYOUT_XOR_IGNORE_LIST) "81/14"
 #set ::env(KLAYOUT_DRC_TECH) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/$::env(PDK).lydrc"
 
 # netgen setup


### PR DESCRIPTION
add KLAYOUT_XOR_IGNORE_LIST
add variable for klayout lmp file

Need confirmation that it is not an issue to ignore `81/14` during xoring gds files from magic and klayout (done as verification step in openlane). As far as I understood, this layer is added by magic and only used by magic for tap distance check ? 