### PR TITLE
Kklayout XOR updates

### DIFF
--- a/gf180mcu/gf180mcu.json
+++ b/gf180mcu/gf180mcu.json
@@ -89,7 +89,7 @@
         "open_pdks": "237959eeddfe01b19f76dd7a500e25b36d36a23f",
         "magic": "be40825e9aadc1bed858801572bef0415444b516",
         "gf180mcu_pdk": "a897aa30369d3bcec87d9d50ce9b01f320f854ef",
-        "gf180mcu_fd_pr": "d5aea8d57f660dec1c468ce3836de4d24f07471c",
+        "gf180mcu_fd_pr": "e50ad570729356f65dd77e8c5f0745a6a27afd6c",
         "gf180mcu_fd_io": "2aeec51ea2824b6cc0b396acfc39f4535f40b23a",
         "gf180mcu_fd_sc_mcu7t5v0": "8743b6f9641eb8707179c4e51703380d4dc90f16",
         "gf180mcu_fd_sc_mcu9t5v0": "376ea56fa36ce7702595ce4e0e3c9357ee38c81c",

--- a/gf180mcu/openlane/config.tcl
+++ b/gf180mcu/openlane/config.tcl
@@ -118,6 +118,7 @@ set ::env(MAGIC_TECH_FILE) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/magic/$::env(
 set ::env(KLAYOUT_TECH) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/gf180mcu.lyt"
 set ::env(KLAYOUT_PROPERTIES) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/gf180mcu.lyp"
 set ::env(KLAYOUT_DRC_TECH_SCRIPT) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/drc/gf180mcu.drc"
+set ::env(KLAYOUT_DEF_LAYER_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/gf180mcu.map"
 
 ## Netgen
 set ::env(NETGEN_SETUP_FILE) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/netgen/$::env(PDK)_setup.tcl"

--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -1009,7 +1009,7 @@ klayout-%: ${KLAYOUT_PATH}
 		cp -rp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/pymacros/* ${KLAYOUT_STAGING_$*}/pymacros/ ; \
 		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lyp ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyp ; \
 		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lyt ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyt ; \
-		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lmp ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lmp ; \
+		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.map ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.map ; \
 	fi
 	# Copy original DRC deck from open_pdks (is this useful?)
 	cp klayout/sky130.lydrc ${KLAYOUT_STAGING_$*}/drc/${SKY130$*}.lydrc

--- a/sky130/openlane/config.tcl
+++ b/sky130/openlane/config.tcl
@@ -90,8 +90,8 @@ set ::env(MAGIC_TECH_FILE) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/magic/TECHNAM
 set ::env(KLAYOUT_TECH) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/$::env(PDK).lyt"
 set ::env(KLAYOUT_PROPERTIES) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/$::env(PDK).lyp"
 set ::env(KLAYOUT_DRC_TECH_SCRIPT) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/drc/$::env(PDK)_mr.drc"
-set ::env(KLAYOUT_DEF_LAYER_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/$::env(PDK).lmp"
-set ::env(KLAYOUT_XOR_IGNORE_LIST) "81/14"
+set ::env(KLAYOUT_DEF_LAYER_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/$::env(PDK).map"
+set ::env(KLAYOUT_XOR_IGNORE_LAYERS) "81/14"
 #set ::env(KLAYOUT_DRC_TECH) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/$::env(PDK).lydrc"
 
 # netgen setup

--- a/sky130/sky130.json
+++ b/sky130/sky130.json
@@ -104,7 +104,7 @@
         "sky130_fd_bd_sram": "be33adbcf188fdeab5c061699847d9d440f7a084",
         "sky130_ml_xx_hd": "6eb3b0718552b034f1bf1870285ff135e3fb2dcb",
         "xschem_sky130": "5fa1b2e30eda4cdc9949a989d7482531a30b56d4",
-        "klayout_sky130": "dc579b007d27180cbf4085d82e01c732fc34e454",
+        "klayout_sky130": "1d53b55625d854ebfdd9f7f2941a35f3ffbdf185",
         "precheck_sky130": "a8a54b74961a43f3a7b85d44843ae2adbc93b233"
     }
 }


### PR DESCRIPTION
update commit references of gf180mcu_fd_pr and klayout_sky130 
rename `.lmp` to `.map` (as observed in github issues of klayout)
rename `KLAYOUT_XOR_IGNORE_LIST` to `KLAYOUT_XOR_IGNORE_LAYERS`
add map file variable for gf180mcu 