### PR TITLE
openlane PDNsim changes

### DIFF
--- a/gf180mcu/openlane/config.tcl
+++ b/gf180mcu/openlane/config.tcl
@@ -4,6 +4,9 @@ set ::env(DEF_UNITS_PER_MICRON) 2000
 
 set ::env(VDD_PIN) "VDD"
 set ::env(GND_PIN) "VSS"
+set ::env(VDD_PIN_VOLTAGE) "5.00"
+set ::env(GND_PIN_VOLTAGE) "0.00"
+
 set ::env(STD_CELL_POWER_PINS) "VDD VNW"
 set ::env(STD_CELL_GROUND_PINS) "VSS VPW"
 

--- a/sky130/openlane/config.tcl
+++ b/sky130/openlane/config.tcl
@@ -14,6 +14,9 @@ if { ![info exist ::env(STD_CELL_LIBRARY_OPT)] } {
 set ::env(VDD_PIN) "VPWR"
 set ::env(GND_PIN) "VGND"
 
+set ::env(VDD_PIN_VOLTAGE) "1.80"
+set ::env(GND_PIN_VOLTAGE) "0.00"
+
 set ::env(STD_CELL_POWER_PINS) "VPWR VPB"
 set ::env(STD_CELL_GROUND_PINS) "VGND VNB"
 

--- a/sky130/openlane/sky130_fd_sc_hvl/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hvl/config.tcl
@@ -2,17 +2,15 @@ set current_folder [file dirname [file normalize [info script]]]
 # Technology lib
 
 #ifdef EF_FORMAT
-set ::env(LIB_SYNTH) "\
-	$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lib/$::env(STD_CELL_LIBRARY)/sky130_fd_sc_hvl__tt_025C_3v30.lib\
-	$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lib/$::env(STD_CELL_LIBRARY)/sky130_fd_sc_hvl__tt_025C_3v30_lv1v80.lib\
-"
+set ::env(LIB_SYNTH) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lib/$::env(STD_CELL_LIBRARY)/sky130_fd_sc_hvl__tt_025C_3v30.lib"
+
+set ::env(VDD_PIN_VOLTAGE) "3.30"
+set ::env(GND_PIN_VOLTAGE) "0.00"
+
 set ::env(LIB_FASTEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lib/$::env(STD_CELL_LIBRARY)/sky130_fd_sc_hvl__ff_n40C_5v50.lib"
 set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lib/$::env(STD_CELL_LIBRARY)/sky130_fd_sc_hvl__ss_150C_1v65.lib"
 #else (!EF_FORMAT)
-set ::env(LIB_SYNTH) "\
-	$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/sky130_fd_sc_hvl__tt_025C_3v30.lib\
-	$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/sky130_fd_sc_hvl__tt_025C_3v30_lv1v80.lib\
-"
+set ::env(LIB_SYNTH) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/sky130_fd_sc_hvl__tt_025C_3v30.lib"
 set ::env(LIB_FASTEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/sky130_fd_sc_hvl__ff_n40C_5v50.lib"
 set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/sky130_fd_sc_hvl__ss_150C_1v65.lib"
 #endif (!EF_FORMAT)

--- a/sky130/openlane/sky130_fd_sc_hvl/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hvl/config.tcl
@@ -4,9 +4,6 @@ set current_folder [file dirname [file normalize [info script]]]
 #ifdef EF_FORMAT
 set ::env(LIB_SYNTH) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lib/$::env(STD_CELL_LIBRARY)/sky130_fd_sc_hvl__tt_025C_3v30.lib"
 
-set ::env(VDD_PIN_VOLTAGE) "3.30"
-set ::env(GND_PIN_VOLTAGE) "0.00"
-
 set ::env(LIB_FASTEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lib/$::env(STD_CELL_LIBRARY)/sky130_fd_sc_hvl__ff_n40C_5v50.lib"
 set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/lib/$::env(STD_CELL_LIBRARY)/sky130_fd_sc_hvl__ss_150C_1v65.lib"
 #else (!EF_FORMAT)
@@ -16,6 +13,9 @@ set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LI
 #endif (!EF_FORMAT)
 
 set ::env(LIB_TYPICAL) $::env(LIB_SYNTH)
+
+set ::env(VDD_PIN_VOLTAGE) "3.30"
+set ::env(GND_PIN_VOLTAGE) "0.00"
 
 # MUX4 mapping
 set ::env(SYNTH_MUX4_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/mux4_map.v"


### PR DESCRIPTION
\+ add `VDD_PIN_VOLTAGE` and `GND_PIN_VOLTAGE` needed by PDNsim for ir drop analysis
\- remove `sky130_fd_sc_hvl__tt_025C_3v30_lv1v80` from `LIB_SYNTH` as it breaks abc in yosys and I don't think level shifters are needed for synth (if I understand correctly that this lib is for level shifters)