### PR TITLE
Allow the addition of a user-specific path for XSCHEM

### DIFF
--- a/gf180mcu/Makefile.in
+++ b/gf180mcu/Makefile.in
@@ -739,6 +739,7 @@ xschem-%: ${GF180MCU_PR_PATH}
 	cp -rp ${GF180MCU_PR_PATH}/cells/xschem/symbols ${XSCHEM_STAGING_$*}
 	cp -rp ${GF180MCU_PR_PATH}/cells/xschem/tests ${XSCHEM_STAGING_$*}
 	cp -rp ${GF180MCU_PR_PATH}/cells/xschem/xschemrc ${XSCHEM_STAGING_$*}
+	cat ./custom/xschem/xschemrc_append >> ${XSCHEM_STAGING_$*}/xschemrc
 
 openlane-%: openlane/config.tcl openlane/gf180mcu_fd_sc_mcu7t5v0/config.tcl openlane/gf180mcu_fd_sc_mcu9t5v0/config.tcl
 	mkdir -p ${OPENLANETOP_STAGING_$*}

--- a/gf180mcu/custom/xschem/xschemrc_append
+++ b/gf180mcu/custom/xschem/xschemrc_append
@@ -1,0 +1,5 @@
+
+# allow a user-specific path add-on (https://github.com/iic-jku/iic-osic-tools/issues/7)
+if { [info exists ::env(XSCHEM_USER_LIBRARY_PATH) ] } {
+    append XSCHEM_LIBRARY_PATH :$env(XSCHEM_USER_LIBRARY_PATH)
+}

--- a/sky130/custom/xschem/xschemrc_append
+++ b/sky130/custom/xschem/xschemrc_append
@@ -6,3 +6,7 @@
 set XSCHEM_START_WINDOW ${PDK_ROOT}/${PDK}/libs.tech/xschem/sky130_tests/top.sch
 append XSCHEM_LIBRARY_PATH :${PDK_ROOT}/${PDK}/libs.tech/xschem
 
+# allow a user-specific path add-on (https://github.com/iic-jku/iic-osic-tools/issues/7)
+if { [info exists ::env(XSCHEM_USER_LIBRARY_PATH) ] } {
+    append XSCHEM_LIBRARY_PATH :$env(XSCHEM_USER_LIBRARY_PATH)
+}


### PR DESCRIPTION
This is a useful feature for containerized installations, see https://github.com/iic-jku/iic-osic-tools/issues/7.