### PR TITLE
lib: make the files well-formed

### DIFF
--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_tt_tt_025C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_tt_tt_025C_1v80_3v30.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_tt_tt_025C_1v80_3v30") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ff_100C_1v95_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ff_100C_1v95_5v50.lib
@@ -142,7 +142,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ff_ff_100C_1v95_5v50") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ff_n40C_1v95_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ff_n40C_1v95_5v50.lib
@@ -158,7 +158,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ff_ff_n40C_1v95_5v50") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ff_n40C_1v95_5v50_nointpwr.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ff_n40C_1v95_5v50_nointpwr.lib
@@ -158,7 +158,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ff_ff_n40C_1v95_5v50_nointpwr") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_100C_1v65_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_100C_1v65_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ff_ss_100C_1v65_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_100C_1v95_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_100C_1v95_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ff_ss_100C_1v95_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-                        is_macro_cell : true
+                        is_macro_cell : true;
 		dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_100C_1v95_1v95.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_100C_1v95_1v95.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ff_ss_100C_1v95_1v95") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_n40C_1v65_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_n40C_1v65_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ff_ss_n40C_1v65_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_n40C_1v95_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_n40C_1v95_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ff_ss_n40C_1v95_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-                        is_macro_cell : true
+                        is_macro_cell : true;
 		dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_n40C_1v95_1v95.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ff_ss_n40C_1v95_1v95.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ff_ss_n40C_1v95_1v95") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ff_100C_1v60_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ff_100C_1v60_5v50.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ss_ff_100C_1v60_5v50") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ff_n40C_1v60_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ff_n40C_1v60_5v50.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ss_ff_n40C_1v60_5v50") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_100C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_100C_1v40_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ss_ss_100C_1v40_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 		dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_100C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_100C_1v60_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ss_ss_100C_1v60_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_100C_1v60_3v00.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_100C_1v60_3v00.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ss_ss_100C_1v60_3v00") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_n40C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_n40C_1v40_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ss_ss_n40C_1v40_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_n40C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_n40C_1v60_1v65.lib
@@ -159,7 +159,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ss_ss_n40C_1v60_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_n40C_1v60_1v65_nointpwr.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_ss_ss_n40C_1v60_1v65_nointpwr.lib
@@ -159,7 +159,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_ss_ss_n40C_1v60_1v65_nointpwr") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_tt_tt_025C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_wrapped_tt_tt_025C_1v80_3v30.lib
@@ -143,7 +143,7 @@ library ("sky130_ef_io__gpiov2_pad_wrapped_tt_tt_025C_1v80_3v30") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_ef_io__gpiov2_pad_wrapped") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ff_n40C_1v95_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ff_n40C_1v95_5v50.lib
@@ -82,7 +82,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ff_n40C_1v95_5v50) {
     voltage	: 1.95	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "Min"	
+  default_operating_conditions : "Min";
 
 cell (sky130_ef_io__vssd_lvc_clamped3_pad) {
     cell_leakage_power :  0.38 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ff_n40C_1v95_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ff_n40C_1v95_5v50.lib
@@ -76,7 +76,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ff_n40C_1v95_5v50) {
   
   voltage_map(VSSD1, 0.00);
 
-  operating_conditions (Min) {
+  operating_conditions ("Min") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.95	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v40_1v65.lib
@@ -82,7 +82,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v40_1v65) {
     voltage	: 1.40	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_max_100"	
+  default_operating_conditions : "deep_sleep_max_100";
 
 cell (sky130_ef_io__vssd_lvc_clamped3_pad) {
     cell_leakage_power :   45;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v40_1v65.lib
@@ -76,7 +76,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v40_1v65) {
   
   voltage_map(VSSD1, 0.00);
 
-  operating_conditions (deep_sleep_max_100) {
+  operating_conditions ("deep_sleep_max_100") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.40	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v45_1v65.lib
@@ -82,7 +82,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v45_1v65) {
     voltage	: 1.45	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_lfclk_max_-40"	
+  default_operating_conditions : "deep_sleep_lfclk_max_-40";
 
 cell (sky130_ef_io__vssd_lvc_clamped3_pad) {
     cell_leakage_power :   47.98 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v45_1v65.lib
@@ -76,7 +76,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v45_1v65) {
   
   voltage_map(VSSD1, 0.00);
 
-  operating_conditions (deep_sleep_lfclk_max_-40) {
+  operating_conditions ("deep_sleep_lfclk_max_-40") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.45	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_1v65.lib
@@ -76,7 +76,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_1v65) {
   
   voltage_map(VSSD1, 0.00);
 
-  operating_conditions (max_ind) {
+  operating_conditions ("max_ind") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.60	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_1v65.lib
@@ -82,7 +82,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_1v65) {
     voltage	: 1.60	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "max_ind"	
+  default_operating_conditions : "max_ind";
 
 cell (sky130_ef_io__vssd_lvc_clamped3_pad) {
     cell_leakage_power :  57.67;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_3v00.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_3v00.lib
@@ -82,7 +82,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_3v00) {
     voltage	: 1.60	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "max_io_ind"	
+  default_operating_conditions : "max_io_ind";
 
 cell (sky130_ef_io__vssd_lvc_clamped3_pad) {
     cell_leakage_power :   57.67 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_3v00.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_3v00.lib
@@ -76,7 +76,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v60_3v00) {
   
   voltage_map(VSSD1, 0.00);
 
-  operating_conditions (max_io_ind) {
+  operating_conditions ("max_io_ind") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.60	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v40_1v65.lib
@@ -76,7 +76,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v40_1v65) {
   
   voltage_map(VSSD1, 0.00);
 
-  operating_conditions (deep_sleep_max_-40) {
+  operating_conditions ("deep_sleep_max_-40") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.40	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v40_1v65.lib
@@ -82,7 +82,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v40_1v65) {
     voltage	: 1.40	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_max_-40"	
+  default_operating_conditions : "deep_sleep_max_-40";
 
 cell (sky130_ef_io__vssd_lvc_clamped3_pad) {
     cell_leakage_power :  0.01 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v45_1v65.lib
@@ -82,7 +82,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v45_1v65) {
     voltage	: 1.45	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_lfclk_max_-40"	
+  default_operating_conditions : "deep_sleep_lfclk_max_-40";
 
 cell (sky130_ef_io__vssd_lvc_clamped3_pad) {
     cell_leakage_power :   0.01;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v45_1v65.lib
@@ -76,7 +76,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v45_1v65) {
   
   voltage_map(VSSD1, 0.00);
 
-  operating_conditions (deep_sleep_lfclk_max_-40) {
+  operating_conditions ("deep_sleep_lfclk_max_-40") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.45	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v60_1v65.lib
@@ -82,7 +82,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v60_1v65) {
     voltage	: 1.60	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "Max"	
+  default_operating_conditions : "Max";
 
 cell (sky130_ef_io__vssd_lvc_clamped3_pad) {
     cell_leakage_power :  0.03 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v60_1v65.lib
@@ -76,7 +76,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_ss_n40C_1v60_1v65) {
   
   voltage_map(VSSD1, 0.00);
 
-  operating_conditions (Max) {
+  operating_conditions ("Max") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.60	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_tt_025C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_tt_025C_1v80_3v30.lib
@@ -82,7 +82,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_tt_025C_1v80_3v30) {
     voltage	: 1.80	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "Typ"	
+  default_operating_conditions : "Typ";
 
 cell (sky130_ef_io__vssd_lvc_clamped3_pad) {
     cell_leakage_power :   2.65;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_tt_025C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_tt_025C_1v80_3v30.lib
@@ -76,7 +76,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_tt_025C_1v80_3v30) {
   
   voltage_map(VSSD1, 0.00);
 
-  operating_conditions (Typ) {
+  operating_conditions ("Typ") {
     process	: 1 ;
     temperature : 025	;
     voltage	: 1.80	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_tt_100C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_tt_100C_1v80_3v30.lib
@@ -82,7 +82,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_tt_100C_1v80_3v30) {
     voltage	: 1.80	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "typ_ind"	
+  default_operating_conditions : "typ_ind";
 
 cell (sky130_ef_io__vssd_lvc_clamped3_pad) {
     cell_leakage_power : 145.39  ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_tt_100C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped3_pad_tt_100C_1v80_3v30.lib
@@ -76,7 +76,7 @@ library (sky130_ef_io__vssd_lvc_clamped3_pad_tt_100C_1v80_3v30) {
   
   voltage_map(VSSD1, 0.00);
 
-  operating_conditions (typ_ind) {
+  operating_conditions ("typ_ind") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.80	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ff_n40C_1v95_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ff_n40C_1v95_5v50.lib
@@ -74,7 +74,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ff_n40C_1v95_5v50) {
 
   
 
-  operating_conditions (Min) {
+  operating_conditions ("Min") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.95	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ff_n40C_1v95_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ff_n40C_1v95_5v50.lib
@@ -80,7 +80,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ff_n40C_1v95_5v50) {
     voltage	: 1.95	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "Min"	
+  default_operating_conditions : "Min";
 
 cell (sky130_ef_io__vssd_lvc_clamped_pad) {
     cell_leakage_power :  0.38 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v40_1v65.lib
@@ -80,7 +80,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v40_1v65) {
     voltage	: 1.40	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_max_100"	
+  default_operating_conditions : "deep_sleep_max_100";
 
 cell (sky130_ef_io__vssd_lvc_clamped_pad) {
     cell_leakage_power :   45;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v40_1v65.lib
@@ -74,7 +74,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v40_1v65) {
 
   
 
-  operating_conditions (deep_sleep_max_100) {
+  operating_conditions ("deep_sleep_max_100") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.40	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v45_1v65.lib
@@ -74,7 +74,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v45_1v65) {
 
   
 
-  operating_conditions (deep_sleep_lfclk_max_-40) {
+  operating_conditions ("deep_sleep_lfclk_max_-40") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.45	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v45_1v65.lib
@@ -80,7 +80,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v45_1v65) {
     voltage	: 1.45	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_lfclk_max_-40"	
+  default_operating_conditions : "deep_sleep_lfclk_max_-40";
 
 cell (sky130_ef_io__vssd_lvc_clamped_pad) {
     cell_leakage_power :   47.98 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_1v65.lib
@@ -80,7 +80,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_1v65) {
     voltage	: 1.60	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "max_ind"	
+  default_operating_conditions : "max_ind";
 
 cell (sky130_ef_io__vssd_lvc_clamped_pad) {
     cell_leakage_power :  57.67;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_1v65.lib
@@ -74,7 +74,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_1v65) {
 
   
 
-  operating_conditions (max_ind) {
+  operating_conditions ("max_ind") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.60	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_3v00.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_3v00.lib
@@ -74,7 +74,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_3v00) {
 
   
 
-  operating_conditions (max_io_ind) {
+  operating_conditions ("max_io_ind") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.60	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_3v00.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_3v00.lib
@@ -80,7 +80,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_100C_1v60_3v00) {
     voltage	: 1.60	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "max_io_ind"	
+  default_operating_conditions : "max_io_ind";
 
 cell (sky130_ef_io__vssd_lvc_clamped_pad) {
     cell_leakage_power :   57.67 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v40_1v65.lib
@@ -74,7 +74,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v40_1v65) {
 
   
 
-  operating_conditions (deep_sleep_max_-40) {
+  operating_conditions ("deep_sleep_max_-40") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.40	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v40_1v65.lib
@@ -80,7 +80,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v40_1v65) {
     voltage	: 1.40	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_max_-40"	
+  default_operating_conditions : "deep_sleep_max_-40";
 
 cell (sky130_ef_io__vssd_lvc_clamped_pad) {
     cell_leakage_power :  0.01 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v45_1v65.lib
@@ -74,7 +74,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v45_1v65) {
 
   
 
-  operating_conditions (deep_sleep_lfclk_max_-40) {
+  operating_conditions ("deep_sleep_lfclk_max_-40") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.45	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v45_1v65.lib
@@ -80,7 +80,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v45_1v65) {
     voltage	: 1.45	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_lfclk_max_-40"	
+  default_operating_conditions : "deep_sleep_lfclk_max_-40";
 
 cell (sky130_ef_io__vssd_lvc_clamped_pad) {
     cell_leakage_power :   0.01;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v60_1v65.lib
@@ -80,7 +80,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v60_1v65) {
     voltage	: 1.60	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "Max"	
+  default_operating_conditions : "Max";
 
 cell (sky130_ef_io__vssd_lvc_clamped_pad) {
     cell_leakage_power :  0.03 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v60_1v65.lib
@@ -74,7 +74,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_ss_n40C_1v60_1v65) {
 
   
 
-  operating_conditions (Max) {
+  operating_conditions ("Max") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.60	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_tt_025C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_tt_025C_1v80_3v30.lib
@@ -74,7 +74,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_tt_025C_1v80_3v30) {
 
   
 
-  operating_conditions (Typ) {
+  operating_conditions ("Typ") {
     process	: 1 ;
     temperature : 025	;
     voltage	: 1.80	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_tt_025C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_tt_025C_1v80_3v30.lib
@@ -80,7 +80,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_tt_025C_1v80_3v30) {
     voltage	: 1.80	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "Typ"	
+  default_operating_conditions : "Typ";
 
 cell (sky130_ef_io__vssd_lvc_clamped_pad) {
     cell_leakage_power :   2.65;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_tt_100C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_tt_100C_1v80_3v30.lib
@@ -74,7 +74,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_tt_100C_1v80_3v30) {
 
   
 
-  operating_conditions (typ_ind) {
+  operating_conditions ("typ_ind") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.80	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_tt_100C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__vssd_lvc_clamped_pad_tt_100C_1v80_3v30.lib
@@ -80,7 +80,7 @@ library (sky130_ef_io__vssd_lvc_clamped_pad_tt_100C_1v80_3v30) {
     voltage	: 1.80	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "typ_ind"	
+  default_operating_conditions : "typ_ind";
 
 cell (sky130_ef_io__vssd_lvc_clamped_pad) {
     cell_leakage_power : 145.39  ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ff_100C_1v95_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ff_100C_1v95_5v50.lib
@@ -142,7 +142,7 @@ library ("sky130_fd_io__top_gpiov2_ff_ff_100C_1v95_5v50") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ff_n40C_1v95_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ff_n40C_1v95_5v50.lib
@@ -158,7 +158,7 @@ library ("sky130_fd_io__top_gpiov2_ff_ff_n40C_1v95_5v50") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ff_n40C_1v95_5v50_nointpwr.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ff_n40C_1v95_5v50_nointpwr.lib
@@ -158,7 +158,7 @@ library ("sky130_fd_io__top_gpiov2_ff_ff_n40C_1v95_5v50_nointpwr") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_100C_1v65_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_100C_1v65_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ff_ss_100C_1v65_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_100C_1v95_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_100C_1v95_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ff_ss_100C_1v95_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-                        is_macro_cell : true
+                        is_macro_cell : true;
 		dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_100C_1v95_1v95.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_100C_1v95_1v95.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ff_ss_100C_1v95_1v95") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_n40C_1v65_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_n40C_1v65_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ff_ss_n40C_1v65_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_n40C_1v95_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_n40C_1v95_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ff_ss_n40C_1v95_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-                        is_macro_cell : true
+                        is_macro_cell : true;
 		dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_n40C_1v95_1v95.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ff_ss_n40C_1v95_1v95.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ff_ss_n40C_1v95_1v95") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ff_100C_1v60_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ff_100C_1v60_5v50.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ss_ff_100C_1v60_5v50") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ff_n40C_1v60_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ff_n40C_1v60_5v50.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ss_ff_n40C_1v60_5v50") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_100C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_100C_1v40_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ss_ss_100C_1v40_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 		dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_100C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_100C_1v60_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ss_ss_100C_1v60_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_100C_1v60_3v00.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_100C_1v60_3v00.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ss_ss_100C_1v60_3v00") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_n40C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_n40C_1v40_1v65.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_ss_ss_n40C_1v40_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 			dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_n40C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_n40C_1v60_1v65.lib
@@ -159,7 +159,7 @@ library ("sky130_fd_io__top_gpiov2_ss_ss_n40C_1v60_1v65") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_n40C_1v60_1v65_nointpwr.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_ss_ss_n40C_1v60_1v65_nointpwr.lib
@@ -159,7 +159,7 @@ library ("sky130_fd_io__top_gpiov2_ss_ss_n40C_1v60_1v65_nointpwr") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_tt_tt_025C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_gpiov2_tt_tt_025C_1v80_3v30.lib
@@ -143,7 +143,7 @@ library ("sky130_fd_io__top_gpiov2_tt_tt_025C_1v80_3v30") {
 		 downto    : true; 
 	 } 
 	cell ("sky130_fd_io__top_gpiov2") {
-			is_macro_cell : true
+			is_macro_cell : true;
 dont_use : true;
 		interface_timing : true;
 		pad_cell : true;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ff_n40C_1v95_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ff_n40C_1v95_5v50.lib
@@ -81,7 +81,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ff_n40C_1v95_5v50) {
   voltage_map(BDY2_B2B, 0.00);
   voltage_map(G_CORE, 0.00);
 
-  operating_conditions (Min) {
+  operating_conditions ("Min") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.95	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ff_n40C_1v95_5v50.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ff_n40C_1v95_5v50.lib
@@ -87,7 +87,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ff_n40C_1v95_5v50) {
     voltage	: 1.95	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "Min"	
+  default_operating_conditions : "Min";
 
 cell (sky130_fd_io__top_ground_lvc_wpad) {
     cell_leakage_power :  0.38 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v40_1v65.lib
@@ -87,7 +87,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v40_1v65) {
     voltage	: 1.40	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_max_100"	
+  default_operating_conditions : "deep_sleep_max_100";
 
 cell (sky130_fd_io__top_ground_lvc_wpad) {
     cell_leakage_power :   45;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v40_1v65.lib
@@ -81,7 +81,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v40_1v65) {
   voltage_map(BDY2_B2B, 0.00);
   voltage_map(G_CORE, 0.00);
 
-  operating_conditions (deep_sleep_max_100) {
+  operating_conditions ("deep_sleep_max_100") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.40	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v45_1v65.lib
@@ -81,7 +81,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v45_1v65) {
   voltage_map(BDY2_B2B, 0.00);
   voltage_map(G_CORE, 0.00);
 
-  operating_conditions (deep_sleep_lfclk_max_-40) {
+  operating_conditions ("deep_sleep_lfclk_max_-40") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.45	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v45_1v65.lib
@@ -87,7 +87,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v45_1v65) {
     voltage	: 1.45	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_lfclk_max_-40"	
+  default_operating_conditions : "deep_sleep_lfclk_max_-40";
 
 cell (sky130_fd_io__top_ground_lvc_wpad) {
     cell_leakage_power :   47.98 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_1v65.lib
@@ -81,7 +81,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_1v65) {
   voltage_map(BDY2_B2B, 0.00);
   voltage_map(G_CORE, 0.00);
 
-  operating_conditions (max_ind) {
+  operating_conditions ("max_ind") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.60	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_1v65.lib
@@ -87,7 +87,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_1v65) {
     voltage	: 1.60	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "max_ind"	
+  default_operating_conditions : "max_ind";
 
 cell (sky130_fd_io__top_ground_lvc_wpad) {
     cell_leakage_power :  57.67;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_3v00.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_3v00.lib
@@ -81,7 +81,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_3v00) {
   voltage_map(BDY2_B2B, 0.00);
   voltage_map(G_CORE, 0.00);
 
-  operating_conditions (max_io_ind) {
+  operating_conditions ("max_io_ind") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.60	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_3v00.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_3v00.lib
@@ -87,7 +87,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_100C_1v60_3v00) {
     voltage	: 1.60	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "max_io_ind"	
+  default_operating_conditions : "max_io_ind";
 
 cell (sky130_fd_io__top_ground_lvc_wpad) {
     cell_leakage_power :   57.67 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v40_1v65.lib
@@ -87,7 +87,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v40_1v65) {
     voltage	: 1.40	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_max_-40"	
+  default_operating_conditions : "deep_sleep_max_-40";
 
 cell (sky130_fd_io__top_ground_lvc_wpad) {
     cell_leakage_power :  0.01 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v40_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v40_1v65.lib
@@ -81,7 +81,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v40_1v65) {
   voltage_map(BDY2_B2B, 0.00);
   voltage_map(G_CORE, 0.00);
 
-  operating_conditions (deep_sleep_max_-40) {
+  operating_conditions ("deep_sleep_max_-40") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.40	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v45_1v65.lib
@@ -87,7 +87,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v45_1v65) {
     voltage	: 1.45	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "deep_sleep_lfclk_max_-40"	
+  default_operating_conditions : "deep_sleep_lfclk_max_-40";
 
 cell (sky130_fd_io__top_ground_lvc_wpad) {
     cell_leakage_power :   0.01;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v45_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v45_1v65.lib
@@ -81,7 +81,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v45_1v65) {
   voltage_map(BDY2_B2B, 0.00);
   voltage_map(G_CORE, 0.00);
 
-  operating_conditions (deep_sleep_lfclk_max_-40) {
+  operating_conditions ("deep_sleep_lfclk_max_-40") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.45	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v60_1v65.lib
@@ -87,7 +87,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v60_1v65) {
     voltage	: 1.60	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "Max"	
+  default_operating_conditions : "Max";
 
 cell (sky130_fd_io__top_ground_lvc_wpad) {
     cell_leakage_power :  0.03 ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v60_1v65.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v60_1v65.lib
@@ -81,7 +81,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_ss_n40C_1v60_1v65) {
   voltage_map(BDY2_B2B, 0.00);
   voltage_map(G_CORE, 0.00);
 
-  operating_conditions (Max) {
+  operating_conditions ("Max") {
     process	: 1 ;
     temperature : -40	;
     voltage	: 1.60	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_tt_025C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_tt_025C_1v80_3v30.lib
@@ -87,7 +87,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_tt_025C_1v80_3v30) {
     voltage	: 1.80	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "Typ"	
+  default_operating_conditions : "Typ";
 
 cell (sky130_fd_io__top_ground_lvc_wpad) {
     cell_leakage_power :   2.65;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_tt_025C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_tt_025C_1v80_3v30.lib
@@ -81,7 +81,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_tt_025C_1v80_3v30) {
   voltage_map(BDY2_B2B, 0.00);
   voltage_map(G_CORE, 0.00);
 
-  operating_conditions (Typ) {
+  operating_conditions ("Typ") {
     process	: 1 ;
     temperature : 025	;
     voltage	: 1.80	;

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_tt_100C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_tt_100C_1v80_3v30.lib
@@ -87,7 +87,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_tt_100C_1v80_3v30) {
     voltage	: 1.80	;
     tree_type	: balanced_tree ;
   }
-  default_operating_conditions : "typ_ind"	
+  default_operating_conditions : "typ_ind";
 
 cell (sky130_fd_io__top_ground_lvc_wpad) {
     cell_leakage_power : 145.39  ;  

--- a/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_tt_100C_1v80_3v30.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_fd_io__top_ground_lvc_wpad_tt_100C_1v80_3v30.lib
@@ -81,7 +81,7 @@ library (sky130_fd_io__top_ground_lvc_wpad_tt_100C_1v80_3v30) {
   voltage_map(BDY2_B2B, 0.00);
   voltage_map(G_CORE, 0.00);
 
-  operating_conditions (typ_ind) {
+  operating_conditions ("typ_ind") {
     process	: 1 ;
     temperature : 100	;
     voltage	: 1.80	;


### PR DESCRIPTION
Here is some shell fragment that helped fixup these issues.

```
# Add missing trailing semi-colon to: is_macro_cell : true;
for f in $(find . -type f -exec egrep -Hinl "is_macro_cell\s*:\s*(true|false)\s+?$" {} \;); do echo $f; sed -e 's#\(is_macro_cell\s*:\s*true\)$#\1;#' -i "$f"; done

# Add missing trailing semi-colon to: 
for f in $(find . -type f -exec egrep -Hinl '"\s*$' {} \;); do echo $f; sed -e 's#\s\+$#;#' -i "$f"; done

# sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v45_1v65.lib:  operating_conditions (deep_sleep_lfclk_max_-40) {
# sky130_ef_io__vssd_lvc_clamped3_pad_ss_100C_1v45_1v65.lib:  operating_conditions ("deep_sleep_lfclk_max_-40") {
for f in $(find . -name "*.lib" -exec egrep -Hni "\([^\"].*\).*{" {} \; | egrep -v "\([a-zA-Z\$_][a-zA-Z0-9\$_]+\)"  | cut -d':' -f1); do \
        echo $f; sed -e 's#operating_conditions (\(.*\))#operating_conditions (\"\1\")#' -i "$f"; done

# operating_conditions(MAX) {
# operating_conditions("MAX") {
for f in $(find . -name "*.lib" -exec egrep -Hnil "operating_conditions\s*\([^\"\)]+\)" {} \;); do \
        echo $f; sed -e 's#\(operating_conditions\s*(\)\([^\)\"]\+\)#\1\"\2\"#' -i "$f"; done 
```