### PR TITLE
gf180mcu: fix klayout lvs path

### DIFF
--- a/gf180mcu/Makefile.in
+++ b/gf180mcu/Makefile.in
@@ -718,7 +718,7 @@ klayout-%: ${GF180MCU_PV_PATH} ${GF180MCU_PR_PATH}
 
 	cp -rp ${GF180MCU_PV_PATH}/klayout/drc/* \
 		${KLAYOUT_STAGING_$*}/drc
-	cp -rp ${GF180MCU_PR_PATH}/rules/klayout/lvs/* \
+	cp -rp ${GF180MCU_PV_PATH}/klayout/lvs/* \
 		${KLAYOUT_STAGING_$*}/lvs
 	cp -rp ${GF180MCU_PR_PATH}/cells/klayout/pymacros/cells/* \
 		${KLAYOUT_STAGING_$*}/pymacros


### PR DESCRIPTION
With https://github.com/efabless/globalfoundries-pdk-libs-gf180mcu_fd_pr/commit/246beab385cfcc17e3b69bf7854e62c1ca79427c the `lvs` was removed from the `pr` repo after moving in `pv`, updating the makerfile to refer to the new location.

Related https://github.com/hdl/conda-eda/issues/333