### PR TITLE
Include specify blocks in cell libraries

### DIFF
--- a/sky130/custom/scripts/fix_verilog.py
+++ b/sky130/custom/scripts/fix_verilog.py
@@ -23,11 +23,6 @@ def filter(inname, outname):
         print('fix_verilog.py: failed to open ' + inname + ' for reading.', file=sys.stderr)
         return 1
 
-    # Check if input file is a base cell or strength-specific cell, and
-    # check if it has a "specify" block file.  To enable this, change
-    # dospecify from False to True.
-    dospecify = False
-
     # Process input with regexp
 
     fixedlines = []

--- a/sky130/custom/scripts/inc_verilog.py
+++ b/sky130/custom/scripts/inc_verilog.py
@@ -28,7 +28,7 @@ def filter(inname, outname):
     # Check if input file is a base cell or strength-specific cell, and
     # check if it has a "specify" block file.  To enable this, change
     # dospecify from False to True.
-    dospecify = False
+    dospecify = True
 
     # Process input with regexp
 
@@ -89,7 +89,39 @@ def filter(inname, outname):
                                         v3text = ispec.read()
                                         v3lines = v3text.splitlines()
                                         for line3 in v3lines:
+
+                                            # Fix issues in specify files
+                                            line3 = line3.replace('RESETB_delayed', 'RESET_B_delayed')
+                                            line3 = line3.replace('GATEN_delayed', 'GATE_N_delayed')
+                                            line3 = line3.replace('AWAKE', 'awake')
+                                            line3 = line3.replace('COND0', 'cond0')
+                                            line3 = line3.replace('COND1', 'cond1')
+                                            line3 = line3.replace('COND2', 'cond2')
+                                            line3 = line3.replace('COND3', 'cond3')
+                                            line3 = line3.replace('COND4', 'cond4')
                                             fixedlines.append(line3)
+
+                            # Fix issues in included files
+                            if '    wire 1             ;' in line2:
+                                continue
+
+                            line2 = line2.replace('\tB2', '   ')
+                            line2 = line2.replace('\tCIN', '    ')
+                            line2 = line2.replace('\tcsi_opt_276,', '             ')
+                            line2 = line2.replace('\tB1', '   ')
+                            line2 = line2.replace('\tA4', '   ')
+                            line2 = line2.replace('\tC1', '   ')
+                            line2 = line2.replace('\tX', '  ')
+                            line2 = line2.replace('\tD', '  ')
+                            line2 = line2.replace('\tbuf_Q', '      ')
+                            line2 = line2.replace('\tgate', '     ')
+                            line2 = line2.replace('\tcsi_opt_296,', '             ')
+                            line2 = line2.replace('\tY', '  ')
+
+                            line2 = line2.replace('    wire  N not0_out          ;', '    wire    not0_out          ;')
+                            line2 = line2.replace('    wire  N nor0_out          ;', '    wire    nor0_out          ;')
+                            line2 = line2.replace('    wire  N nand0_out         ;', '    wire    nand0_out         ;')
+
                             fixedlines.append(line2)
             else:
                 # single-dot:  Ignore this line


### PR DESCRIPTION
This PR includes the specify blocks in all sky130 cell libraries.

- enables `dospecify` to include the specify blocks in `inc_verilog.py`
  (`dospecify` was removed from `fix_verilog.py` because it doesn't do anything there)
- fixes issues inside the specify blocks
    - different naming (e.g. `RESETB_delayed` -> `RESET_B_delayed`)
    - lower-case (e.g. `AWAKE` -> `awake`)
- fixes issues inside the cells
    - some cells contained text fragments that definitely did not belong there
      (e.g. [sky130_fd_sc_hs__a2bb2o](https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hs/blob/1d051f49bfe4e2fe9108d702a8bc2e9c081005a4/cells/a2bb2o/sky130_fd_sc_hs__a2bb2o.behavioral.v) on line 59 and 60)

The following cell libraries have been successfully read in with Icarus Verilog. All four combinations of `USE_POWER_PINS` defined/not-defined and `FUNCTIONAL` defined/not-defined were tested.

	- `sky130_fd_io/verilog/sky130_ef_io.v`
	- `sky130_fd_io/verilog/sky130_fd_io.v`
	- `sky130_fd_sc_hd/verilog/primitives.v`
	- `sky130_fd_sc_hd/verilog/sky130_fd_sc_hd.v`
	- `sky130_fd_sc_hdll/verilog/primitives.v`
	- `sky130_fd_sc_hdll/verilog/sky130_fd_sc_hdll.v`
	- `sky130_fd_sc_hs/verilog/primitives.v`
	- `sky130_fd_sc_hs/verilog/sky130_fd_sc_hs.v`
	- `sky130_fd_sc_hvl/verilog/primitives.v`
	- `sky130_fd_sc_hvl/verilog/sky130_fd_sc_hvl.v`
	- `sky130_fd_sc_lp/verilog/primitives.v`
	- `sky130_fd_sc_lp/verilog/sky130_fd_sc_lp.v`
	- `sky130_fd_sc_ls/verilog/primitives.v`
	- `sky130_fd_sc_ls/verilog/sky130_fd_sc_ls.v`
	- `sky130_fd_sc_ms/verilog/primitives.v`
	- `sky130_fd_sc_ms/verilog/sky130_fd_sc_ms.v`

Additionally, a simple simulation with IOPATH delays was run for `sky130_fd_sc_hd`.

### Problem: SDF-File

Currently, the SDF file generated by OpenROAD annotates the drive-strength specific cells:

```
 (CELL
  (CELLTYPE "sky130_fd_sc_hd__inv_1")
  (INSTANCE _43_)
  (DELAY
   (ABSOLUTE
    (IOPATH A Y (0.059:0.059:0.059) (0.041:0.041:0.041))
   )
  )
 )
```

But this PR adds the specify paths to the base cells. This seems to be the right thing to do here, since the cells are structured in a way that all conditions, notifiers, delayed signals for the timing checks are in the base cell. Moving them to the drive-strength specific cells would mean a major rewrite of the cell libraries.

Therefore, the SDF file needs to be changed like so:

```
 (CELL
  (CELLTYPE "sky130_fd_sc_hd__inv")
  (INSTANCE _43_.base)
  (DELAY
   (ABSOLUTE
    (IOPATH A Y (0.059:0.059:0.059) (0.041:0.041:0.041))
   )
  )
 )
```

I will open an Issue with OpenROAD to ask ask if OpenSTA's `write_sdf` can be changed to output the SDF file in this format.