### PR TITLE
Fix Power Pins of `sky130_ef_sc_hd`

### DIFF
--- a/sky130/custom/sky130_fd_sc_hd/Readme.txt
+++ b/sky130/custom/sky130_fd_sc_hd/Readme.txt
@@ -1,0 +1,3 @@
+These decap cells were redesigned to cut back on its use of the LI layer because the corresponding SkyWater cell was covered in something like 70-80% LI, and using enough of the decap in any one design would cause an LI density error.
+
+The fill cells were redesigned to add tap diffusion in the middle because otherwise the spacing of the nwells and the height of the cells prevents FOM fill, resulting in a different density error.

--- a/sky130/custom/sky130_fd_sc_hd/lef/sky130_ef_sc_hd__decap_12.lef
+++ b/sky130/custom/sky130_fd_sc_hd/lef/sky130_ef_sc_hd__decap_12.lef
@@ -22,12 +22,16 @@ MACRO sky130_ef_sc_hd__decap_12
     END
   END VPWR
   PIN VPB
+    DIRECTION INOUT ;
+    USE POWER ;
     PORT
       LAYER nwell ;
         RECT -0.190 1.305 5.710 2.910 ;
     END
   END VPB
   PIN VNB
+    DIRECTION INOUT ;
+    USE GROUND ;
     PORT
       LAYER pwell ;
         RECT 0.005 0.105 5.515 0.915 ;

--- a/sky130/custom/sky130_fd_sc_hd/lef/sky130_ef_sc_hd__fakediode_2.lef
+++ b/sky130/custom/sky130_fd_sc_hd/lef/sky130_ef_sc_hd__fakediode_2.lef
@@ -28,12 +28,16 @@ MACRO sky130_ef_sc_hd__fakediode_2
     END
   END VPWR
   PIN VPB
+    DIRECTION INOUT ;
+    USE POWER ;
     PORT
       LAYER nwell ;
         RECT -0.190 1.305 1.110 2.910 ;
     END
   END VPB
   PIN VNB
+    DIRECTION INOUT ;
+    USE GROUND ;
     PORT
       LAYER pwell ;
         RECT 0.025 0.065 0.915 1.015 ;

--- a/sky130/custom/sky130_fd_sc_hd/lef/sky130_ef_sc_hd__fill_12.lef
+++ b/sky130/custom/sky130_fd_sc_hd/lef/sky130_ef_sc_hd__fill_12.lef
@@ -22,12 +22,16 @@ MACRO sky130_ef_sc_hd__fill_12
     END
   END VGND
   PIN VPB
+    DIRECTION INOUT ;
+    USE POWER ;
     PORT
       LAYER nwell ;
         RECT -0.190 1.305 2.950 2.910 ;
     END
   END VPB
   PIN VNB
+    DIRECTION INOUT ;
+    USE GROUND ;
     PORT
       LAYER pwell ;
         RECT 0.005 0.105 2.755 0.915 ;

--- a/sky130/custom/sky130_fd_sc_hd/lef/sky130_ef_sc_hd__fill_4.lef
+++ b/sky130/custom/sky130_fd_sc_hd/lef/sky130_ef_sc_hd__fill_4.lef
@@ -22,12 +22,16 @@ MACRO sky130_ef_sc_hd__fill_4
     END
   END VPWR
   PIN VPB
+    DIRECTION INOUT ;
+    USE POWER ;
     PORT
       LAYER nwell ;
         RECT -0.190 1.305 2.030 2.910 ;
     END
   END VPB
   PIN VNB
+    DIRECTION INOUT ;
+    USE GROUND ;
     PORT
       LAYER pwell ;
         RECT 0.025 0.065 1.815 1.015 ;

--- a/sky130/custom/sky130_fd_sc_hd/lef/sky130_ef_sc_hd__fill_8.lef
+++ b/sky130/custom/sky130_fd_sc_hd/lef/sky130_ef_sc_hd__fill_8.lef
@@ -22,12 +22,16 @@ MACRO sky130_ef_sc_hd__fill_8
     END
   END VPWR
   PIN VPB
+    DIRECTION INOUT ;
+    USE POWER ;
     PORT
       LAYER nwell ;
         RECT -0.190 1.305 3.870 2.910 ;
     END
   END VPB
   PIN VNB
+    DIRECTION INOUT ;
+    USE GROUND ;
     PORT
       LAYER pwell ;
         RECT 0.025 0.065 3.655 1.015 ;


### PR DESCRIPTION
Adds correct direction and power attributes to LEF views of `sky130_ef_sc_hd` cells.

I also added a Readme with your Slack comment for documentation purposes.

---

Resolves #397 