### PR TITLE
Remove base instances from custom cells

### DIFF
--- a/sky130/custom/sky130_fd_sc_hd/verilog/sky130_ef_sc_hd__decap_12.v
+++ b/sky130/custom/sky130_fd_sc_hd/verilog/sky130_ef_sc_hd__decap_12.v
@@ -45,12 +45,12 @@ module sky130_ef_sc_hd__decap_12 (
     VNB
 );
 
+    // Module ports
     input VPWR;
     input VGND;
     input VPB ;
     input VNB ;
     // No contents.
-
 endmodule
 `endcelldefine
 
@@ -70,6 +70,7 @@ endmodule
 
 `celldefine
 module sky130_ef_sc_hd__decap_12 ();
+
     // Voltage supply signals
     supply1 VPWR;
     supply0 VGND;

--- a/sky130/custom/sky130_fd_sc_hd/verilog/sky130_ef_sc_hd__fakediode_2.v
+++ b/sky130/custom/sky130_fd_sc_hd/verilog/sky130_ef_sc_hd__fakediode_2.v
@@ -27,8 +27,7 @@
  * every pin without making a connection.  If the net needs an antenna
  * tiedown, the fakediode cell can be replaced by the real diode cell.
  *
- * Verilog wrapper for diode with size of 2 units.  Note that the wrapper
- * is around the original SkyWater diode base cell;  because the diode
+ * Verilog wrapper for diode with size of 2 units. Because the diode
  * has no function in verilog, there is no difference between the verilog
  * definitions of the diode and fake diode other than the cell name.
  *
@@ -50,19 +49,13 @@ module sky130_ef_sc_hd__fakediode_2 (
     VNB
 );
 
+    // Module ports
     input DIODE;
     input VPWR ;
     input VGND ;
     input VPB  ;
     input VNB  ;
-    sky130_fd_sc_hd__diode base (
-        .DIODE(DIODE),
-        .VPWR(VPWR),
-        .VGND(VGND),
-        .VPB(VPB),
-        .VNB(VNB)
-    );
-
+     // No contents.
 endmodule
 `endcelldefine
 
@@ -75,6 +68,7 @@ module sky130_ef_sc_hd__fakediode_2 (
     DIODE
 );
 
+    // Module ports
     input DIODE;
 
     // Voltage supply signals
@@ -82,11 +76,7 @@ module sky130_ef_sc_hd__fakediode_2 (
     supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
-
-    sky130_fd_sc_hd__diode base (
-        .DIODE(DIODE)
-    );
-
+     // No contents.
 endmodule
 `endcelldefine
 

--- a/sky130/custom/sky130_fd_sc_hd/verilog/sky130_ef_sc_hd__fill_12.v
+++ b/sky130/custom/sky130_fd_sc_hd/verilog/sky130_ef_sc_hd__fill_12.v
@@ -35,23 +35,17 @@
 
 `celldefine
 module sky130_ef_sc_hd__fill_12 (
-    VPWR ,
-    VGND ,
-    VPB  ,
+    VPWR,
+    VGND,
+    VPB ,
     VNB
 );
 
-    input VPWR ;
-    input VGND ;
-    input VPB  ;
-    input VNB  ;
-    sky130_fd_sc_hd__fill base (
-        .VPWR(VPWR),
-        .VGND(VGND),
-        .VPB(VPB),
-        .VNB(VNB)
-    );
-
+    input VPWR;
+    input VGND;
+    input VPB ;
+    input VNB ;
+    // No contents.
 endmodule
 `endcelldefine
 
@@ -60,18 +54,14 @@ endmodule
 /*********************************************************/
 
 `celldefine
-module sky130_ef_sc_hd__fill_12 (
-);
+module sky130_ef_sc_hd__fill_12 ();
 
     // Voltage supply signals
     supply1 VPWR;
     supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
-
-    sky130_fd_sc_hd__fill base (
-    );
-
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/sky130/custom/sky130_fd_sc_hd/verilog/sky130_ef_sc_hd__fill_8.v
+++ b/sky130/custom/sky130_fd_sc_hd/verilog/sky130_ef_sc_hd__fill_8.v
@@ -41,11 +41,12 @@ module sky130_ef_sc_hd__fill_8 (
     VNB
 );
 
+    // Module ports
     input VPWR;
     input VGND;
     input VPB ;
     input VNB ;
-
+    // No contents.
 endmodule
 `endcelldefine
 
@@ -55,12 +56,13 @@ endmodule
 
 `celldefine
 module sky130_ef_sc_hd__fill_8 ();
+
     // Voltage supply signals
     supply1 VPWR;
     supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
-
+    // No contents.
 endmodule
 `endcelldefine
 


### PR DESCRIPTION
During the refactoring of the standard cell libraries, all base instances were inlined into the respective modules.
Unfortunately, this was not done for the custom cells in `open_pdks`. If `sky130_fd_sc_hd.v` is read into Icarus Verilog without specifying a top module, it throws errors due to missing modules.

This PR removes the base instances from `sky130_ef_sc_hd__fakediode_2` and `sky130_ef_sc_hd__fill_12` and unifies some of the formatting. The standard cell libraries were built and read with iverilog, which is now happy:

```
iverilog primitives.v sky130_fd_sc_hd.v
```