### PR TITLE
Fix `download.sh`

### DIFF
--- a/gf180mcu/gf180mcu.json
+++ b/gf180mcu/gf180mcu.json
@@ -65,8 +65,8 @@
     "stdcells": {
         "gf180mcu_fd_sc_mcu9t5v0": "FD_SC_MCU9T5V0_COMMIT",
         "gf180mcu_fd_sc_mcu7t5v0": "FD_SC_MCU7T5V0_COMMIT",
-	"gf180mcu_osu_sc_gf12t3v3": "OSU_SC_COMMIT",
-	"gf180mcu_osu_sc_gf9t3v3": "OSU_SC_COMMIT"
+        "gf180mcu_osu_sc_gf12t3v3": "OSU_SC_COMMIT",
+        "gf180mcu_osu_sc_gf9t3v3": "OSU_SC_COMMIT"
     },
     "iocells": {
         "gf180mcu_fd_io": "FD_IO_COMMIT"
@@ -98,7 +98,7 @@
         "gf180mcu_fd_sc_mcu7t5v0": "8743b6f9641eb8707179c4e51703380d4dc90f16",
         "gf180mcu_fd_sc_mcu9t5v0": "376ea56fa36ce7702595ce4e0e3c9357ee38c81c",
         "gf180mcu_fd_ip_sram": "9c411928870ce15226228fa52ddb6ecc0ea4ffbe",
-	"gf180mcu_osu_sc_gf12t3v3": "df1d8ec95b2cfbfdb8e0128819e9899e968b92a4",
-	"gf180mcu_osu_sc_gf9t3v3": "df1d8ec95b2cfbfdb8e0128819e9899e968b92a4"
+        "gf180mcu_osu_sc_gf12t3v3": "df1d8ec95b2cfbfdb8e0128819e9899e968b92a4",
+        "gf180mcu_osu_sc_gf9t3v3": "df1d8ec95b2cfbfdb8e0128819e9899e968b92a4"
     }
 }

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -27,14 +27,14 @@
 # the form on github where the filename is spelled out as ".tar.gz" and
 # not ".tgz")
 
-function GIT() {
+function git_retry() {
     set -Eeuo pipefail
     RETRIES_NO=5
     RETRY_DELAY=3
     for i in $(seq 1 $RETRIES_NO); do
         git $@ && break
         sleep ${RETRY_DELAY}
-        [[ $i -eq $RETRIES_NO ]] && echo "Failed to execute git cmd after $RETRIES_NO retries" && exit 1
+        [[ $i -eq $RETRIES_NO ]] && echo "Failed to execute git cmd after $RETRIES_NO retries" && return 1
     done
 }
 
@@ -83,15 +83,15 @@ else
         echo "Cloning $1 to $2"
         if [ $# -gt 2 ]; then
             if [ "$3" == "unknown" ]; then
-                GIT clone --depth 1 $1 $2
+                git_retry clone --depth 1 $1 $2
             else
                 # git clone $1 $2
                 # git checkout $3
-                { GIT clone --branch $3 --single-branch $1 $2; } || \
-                { GIT clone $1 $2 && GIT -C $2 checkout $3; }
+                { git clone --branch $3 --single-branch $1 $2; } || \ # Not gonna retry- this is more likely to fail than not
+                { git_retry clone $1 $2 && git -C $2 checkout $3; }
             fi
         else
-            GIT clone --depth 1 $1 $2
+            git_retry clone --depth 1 $1 $2
         fi
 
     else


### PR DESCRIPTION
* Renamed `GIT` to `git_retry` (more descriptive)
* Made `git_retry` return an error code instead of exiting unilaterally
* Removed `git_retry` from `git clone -- branch` -- it already has a fallback on failure
* Removed `git_retry` from `checkout` command (offline)
* misc: Fixed indentation of `gf180mcu/gf180mcu.json`