### PR TITLE
Fix OpenLane Config for `gf180mcu`

### DIFF
--- a/gf180mcu/openlane/config.tcl
+++ b/gf180mcu/openlane/config.tcl
@@ -18,9 +18,9 @@ if { ![info exist ::env(STD_CELL_LIBRARY_OPT)] } {
 }
 
 # Lib Files
-set ::env(LIB_SYNTH) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/liberty/$::env(STD_CELL_LIBRARY)__tt_025C_5v00.lib"
-set ::env(LIB_FASTEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/liberty/$::env(STD_CELL_LIBRARY)__ff_n40C_5v50.lib"
-set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/liberty/$::env(STD_CELL_LIBRARY)__ss_125C_4v50.lib"
+set ::env(LIB_SYNTH) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/$::env(STD_CELL_LIBRARY)__tt_025C_5v00.lib"
+set ::env(LIB_FASTEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/$::env(STD_CELL_LIBRARY)__ff_n40C_5v50.lib"
+set ::env(LIB_SLOWEST) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/$::env(STD_CELL_LIBRARY)__ss_125C_4v50.lib"
 
 set ::env(LIB_TYPICAL) $::env(LIB_SYNTH)
 

--- a/gf180mcu/qflow/gf180mcu.sh
+++ b/gf180mcu/qflow/gf180mcu.sh
@@ -25,7 +25,7 @@ set spicefile=LOCAL_PREFIX/TECHNAME/libs.ref/LIBRARY/spice/LIBRARY.spice
 #ifdef EF_STYLE
 set libertyfile=LOCAL_PREFIX/TECHNAME/libs.ref/lib/LIBRARY/LIBRARY__ss_1p62v_125c.lib
 #else
-set libertyfile=LOCAL_PREFIX/TECHNAME/libs.ref/LIBRARY/liberty/LIBRARY__ss_1p62v_125c.lib
+set libertyfile=LOCAL_PREFIX/TECHNAME/libs.ref/LIBRARY/lib/LIBRARY__ss_1p62v_125c.lib
 #endif
 
 # If there is another LEF file containing technology information


### PR DESCRIPTION
Version 1.0.462 changed the directory name for lib files from `liberty` to `lib`, but this was not reflected in the OpenLane config, which causes the liberty files to not be found.

I've also taken the liberty (pun not intended) of updating the path in `qflow/gf180mcu.sh`, just in case.