### PR TITLE
openlane config: update fill/decap cell mixes

### DIFF
--- a/sky130/openlane/sky130_fd_sc_hd/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hd/config.tcl
@@ -47,8 +47,8 @@ set ::env(CELL_CLK_PORT) CLK
 set ::env(PL_LIB) $::env(LIB_TYPICAL)
 
 # Fillcell insertion
-set ::env(FILL_CELL) "sky130_fd_sc_hd__fill*"
-set ::env(DECAP_CELL) "sky130_ef_sc_hd__decap_12 sky130_fd_sc_hd__decap_8 sky130_fd_sc_hd__decap_6 sky130_fd_sc_hd__decap_4 sky130_fd_sc_hd__decap_3"
+set ::env(FILL_CELL) "sky130_fd_sc_hd__fill_2 sky130_fd_sc_hd__fill_1"
+set ::env(DECAP_CELL) "sky130_fd_sc_hd__decap_3"
 set ::env(RE_BUFFER_CELL) "sky130_fd_sc_hd__buf_4"
 
 # Diode insertaion

--- a/sky130/openlane/sky130_fd_sc_hdll/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hdll/config.tcl
@@ -45,7 +45,7 @@ set ::env(PL_LIB) $::env(LIB_TYPICAL)
 
 # Fillcell insertion
 set ::env(FILL_CELL) "sky130_fd_sc_hdll__fill*"
-set ::env(DECAP_CELL) "sky130_fd_sc_hdll__decap_"
+set ::env(DECAP_CELL) "sky130_fd_sc_hdll__decap*"
 set ::env(RE_BUFFER_CELL) "sky130_fd_sc_hdll__buf_4"
 
 # Diode insertaion

--- a/sky130/openlane/sky130_fd_sc_hvl/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_hvl/config.tcl
@@ -52,7 +52,7 @@ set ::env(PL_LIB) $::env(LIB_TYPICAL)
 
 # Fillcell insertion
 set ::env(FILL_CELL) "sky130_fd_sc_hvl__fill*"
-set ::env(DECAP_CELL) "sky130_fd_sc_hvl__decap_"
+set ::env(DECAP_CELL) "sky130_fd_sc_hvl__decap*"
 set ::env(RE_BUFFER_CELL) "sky130_fd_sc_hvl__buf_1"
 
 # Diode insertaion

--- a/sky130/openlane/sky130_fd_sc_ls/config.tcl
+++ b/sky130/openlane/sky130_fd_sc_ls/config.tcl
@@ -48,7 +48,7 @@ set ::env(PL_LIB) $::env(LIB_TYPICAL)
 
 # Fillcell insertion
 set ::env(FILL_CELL) "sky130_fd_sc_ls__fill*"
-set ::env(DECAP_CELL) "sky130_fd_sc_ls__decap_"
+set ::env(DECAP_CELL) "sky130_fd_sc_ls__decap*"
 set ::env(RE_BUFFER_CELL) "sky130_fd_sc_ls__buf_4"
 
 # Diode insertaion


### PR DESCRIPTION
* sky130_fd_sc_hd: use fill mixture that tends to pass poly density rules as per Anton Blanchard
* sky130_fd_sc_{hdll, hvl, ls}: fix wildcards for decap cells