### PR TITLE
Adjust paths for klayout restructuring

### DIFF
--- a/sky130/Makefile.in
+++ b/sky130/Makefile.in
@@ -1221,10 +1221,13 @@ klayout-%: ${KLAYOUT_PATH}
 		rm -rf ${KLAYOUT_STAGING_$*} ; \
 		mkdir -p ${KLAYOUT_STAGING_$*} ; \
 		mkdir -p ${KLAYOUT_STAGING_$*}/tech ; \
+		mkdir -p ${KLAYOUT_STAGING_$*}/tech/xsect ; \
+		mkdir -p ${KLAYOUT_STAGING_$*}/d25 ; \
 		mkdir -p ${KLAYOUT_STAGING_$*}/drc ; \
 		mkdir -p ${KLAYOUT_STAGING_$*}/lvs ; \
-		mkdir -p ${KLAYOUT_STAGING_$*}/scripts ; \
+		mkdir -p ${KLAYOUT_STAGING_$*}/macros ; \
 		mkdir -p ${KLAYOUT_STAGING_$*}/pymacros ; \
+		mkdir -p ${KLAYOUT_STAGING_$*}/python ; \
 	fi
 	# Copy lvs and pymacro directories from the repository.  Other files
 	# are rearranged to the preferred structure.  Do not recursively copy
@@ -1232,12 +1235,16 @@ klayout-%: ${KLAYOUT_PATH}
 	# nonessential.
 	# Additionally, replace "sky130.lyp" with the pdk variant.
 	if test "x${KLAYOUT_PATH}" != "x" ; then \
-		cp -p ${KLAYOUT_PATH}/sky130_tech/tech/sky130/lvs/* ${KLAYOUT_STAGING_$*}/lvs/ ; \
-		cp -rp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/pymacros/* ${KLAYOUT_STAGING_$*}/pymacros/ ; \
-		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lyp ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyp ; \
-		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.lyt ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyt ; \
-		cp ${KLAYOUT_PATH}/sky130_tech/tech/sky130/${TECH}.map ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.map ; \
+		cp ${KLAYOUT_PATH}/tech/sky130/${TECH}.lyp ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyp ; \
+		cp ${KLAYOUT_PATH}/tech/sky130/${TECH}.lyt ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyt ; \
+		cp ${KLAYOUT_PATH}/tech/sky130/${TECH}.map ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.map ; \
 		${SED} -i "s/sky130.lyp/${SKY130$*}.lyp/g" ${KLAYOUT_STAGING_$*}/tech/${SKY130$*}.lyt ; \
+		cp -p ${KLAYOUT_PATH}/tech/sky130/d25/* ${KLAYOUT_STAGING_$*}/d25/ ; \
+		cp -p ${KLAYOUT_PATH}/tech/sky130/lvs/* ${KLAYOUT_STAGING_$*}/lvs/ ; \
+		cp -p ${KLAYOUT_PATH}/tech/sky130/macros/* ${KLAYOUT_STAGING_$*}/macros/ ; \
+		cp -p ${KLAYOUT_PATH}/tech/sky130/pymacros/* ${KLAYOUT_STAGING_$*}/pymacros/ ; \
+		cp -rp ${KLAYOUT_PATH}/tech/sky130/python/* ${KLAYOUT_STAGING_$*}/python/ ; \
+		cp -p ${KLAYOUT_PATH}/tech/sky130/xsect/* ${KLAYOUT_STAGING_$*}/tech/xsect/ ; \
 	fi
 	# Copy original DRC deck from open_pdks (is this useful?)
 	cp klayout/sky130.lydrc ${KLAYOUT_STAGING_$*}/drc/${SKY130$*}.lydrc

--- a/sky130/sky130.json
+++ b/sky130/sky130.json
@@ -113,7 +113,7 @@
         "sky130_fd_pr_reram": "d6d2a3c6960aac0a0b12fc21221c31777bbf284d",
         "sky130_ml_xx_hd": "6eb3b0718552b034f1bf1870285ff135e3fb2dcb",
         "xschem_sky130": "0597d6cd26ad460d3f4d689f9e6a11f33dc262ff",
-        "klayout_sky130": "44068ad98afa18001487177515cac16f3e61094a",
+        "klayout_sky130": "68b8aa87c129191f642da662d348e9ca6930581b",
         "precheck_sky130": "a1a22717e5618f8df329e0c714b43c08fd003543"
     }
 }


### PR DESCRIPTION
Now that https://github.com/efabless/sky130_klayout_pdk/pull/25 has been merged, the paths in open_pdks need to be adjusted.

This PR does exactly that.