### PR TITLE
Remove entry to XSCHEM_LIBRARY_PATH

### DIFF
--- a/sky130/custom/xschem/xschemrc_append
+++ b/sky130/custom/xschem/xschemrc_append
@@ -4,7 +4,6 @@
 # This overrides some of the variables set above.
 
 set XSCHEM_START_WINDOW ${PDK_ROOT}/${PDK}/libs.tech/xschem/sky130_tests/top.sch
-append XSCHEM_LIBRARY_PATH :${PDK_ROOT}/${PDK}/libs.tech/xschem
 
 # allow a user-specific path add-on (https://github.com/iic-jku/iic-osic-tools/issues/7)
 if { [info exists ::env(XSCHEM_USER_LIBRARY_PATH) ] } {


### PR DESCRIPTION
Since the current directory of the xschemrc is now appended to XSCHEM_LIBRARY_PATH via `[file dirname [info script]]`, it is no longer necessary to add `${PDK_ROOT}/${PDK}/libs.tech/xschem`.

This prevents a double entry of the PDKs directory when inserting a symbol in xschem.