### PR TITLE
Fixed a drc error in sky130_fd_bs_flash__special_sonosfet_star

### DIFF
--- a/sky130/magic/sky130.tcl
+++ b/sky130/magic/sky130.tcl
@@ -7145,6 +7145,7 @@ proc sky130::sky130_fd_bs_flash__special_sonosfet_star_draw {parameters} {
 	    id_surround		1.355 \
 	    min_effl		0.185 \
 	    min_allc		0.26 \
+	    gate_to_diffcont	0.158 \
     ]
     set drawdict [dict merge $sky130::ruleset $newdict $parameters]
     return [sky130::mos_draw $drawdict]


### PR DESCRIPTION
Increased gate_to_diffcont from 0.145 to 0.158, to fix the following DRC error: Diffusion contact to SONOS gate < 0.075um.

Tested and found 0.158 to be the minimal value that fixes this DRC issue.