### PR TITLE
Add support for PDK_ROOT in run_standard_drc.py

### DIFF
--- a/sky130/custom/scripts/run_standard_drc.py
+++ b/sky130/custom/scripts/run_standard_drc.py
@@ -111,6 +111,9 @@ def run_full_drc(layout_name, output_file):
         elif 'PDK_PATH' in myenv:
             rcpathroot = myenv['PDKPATH'] + '/libs.tech/magic'
             rcfile = glob.glob(rcpathroot + '/*.magicrc')[0]
+        elif 'PDK_ROOT' in myenv and 'PDK' in myenv:
+            rcpathroot = myenv['PDK_ROOT'] + '/' + myenv['PDK'] + '/libs.tech/magic'
+            rcfile = glob.glob(rcpathroot + '/*.magicrc')[0]
         else:
             print('Error: Cannot get magic rcfile for the technology!')
             return


### PR DESCRIPTION
This script was forgotten in 76760025e18728fb9705a4b2bf10dda0513b5bdd ; the fix done here is identical to the one to check_antenna.py in the referenced commit.