### PR TITLE
sky130: improve pin access in gpiov2_pad LEF

### DIFF
--- a/sky130/custom/sky130_fd_io/lef/sky130_ef_io__gpiov2_pad.lef
+++ b/sky130/custom/sky130_fd_io/lef/sky130_ef_io__gpiov2_pad.lef
@@ -44,7 +44,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met3 ;
-        RECT 45.865 -2.035 46.195 34.770 ;
+        RECT 45.865 -2.035 46.195 0.000 ;
     END
   END ANALOG_POL
   PIN ANALOG_SEL
@@ -52,7 +52,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 30.750 -2.035 31.010 0.230 ;
+        RECT 30.750 -2.035 31.010 0.000 ;
     END
   END ANALOG_SEL
   PIN DM[2]
@@ -60,7 +60,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 28.490 -2.035 28.750 2.035 ;
+        RECT 28.490 -2.035 28.750 0.000 ;
     END
   END DM[2]
   PIN DM[1]
@@ -92,7 +92,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 38.390 -2.035 38.650 1.055 ;
+        RECT 38.390 -2.035 38.650 0.000 ;
     END
   END ENABLE_INP_H
   PIN ENABLE_VDDA_H
@@ -100,7 +100,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 12.755 -2.035 13.015 3.315 ;
+        RECT 12.755 -2.035 13.015 0.000 ;
     END
   END ENABLE_VDDA_H
   PIN ENABLE_VDDIO
@@ -108,7 +108,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met3 ;
-        RECT 78.580 -2.035 78.910 182.740 ;
+        RECT 78.580 -2.035 78.910 0.000 ;
     END
   END ENABLE_VDDIO
   PIN ENABLE_VSWITCH_H
@@ -116,7 +116,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 16.310 -2.035 16.570 0.285 ;
+        RECT 16.310 -2.035 16.570 0.000 ;
     END
   END ENABLE_VSWITCH_H
   PIN HLD_H_N
@@ -124,7 +124,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 31.815 -2.035 32.075 1.305 ;
+        RECT 31.815 -2.035 32.075 0.000 ;
     END
   END HLD_H_N
   PIN HLD_OVR
@@ -132,7 +132,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 26.600 -2.035 26.860 0.670 ;
+        RECT 26.600 -2.035 26.860 0.000 ;
     END
   END HLD_OVR
   PIN IB_MODE_SEL
@@ -140,7 +140,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 5.420 -2.035 5.650 2.440 ;
+        RECT 5.420 -2.035 5.650 0.000 ;
     END
   END IB_MODE_SEL
   PIN IN
@@ -148,7 +148,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met3 ;
-        RECT 79.240 -2.035 79.570 187.525 ;
+        RECT 79.240 -2.035 79.570 0.000 ;
     END
   END IN
   PIN IN_H
@@ -156,7 +156,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met3 ;
-        RECT 0.400 -2.035 1.020 176.450 ;
+        RECT 0.400 -2.035 1.020 0.000 ;
     END
   END IN_H
   PIN INP_DIS
@@ -164,7 +164,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 45.245 -2.035 45.505 3.055 ;
+        RECT 45.245 -2.035 45.505 0.000 ;
     END
   END INP_DIS
   PIN OE_N
@@ -172,7 +172,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 3.375 -2.035 3.605 2.440 ;
+        RECT 3.375 -2.035 3.605 0.000 ;
     END
   END OE_N
   PIN OUT
@@ -180,7 +180,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 22.355 -2.035 22.615 4.390 ;
+        RECT 22.355 -2.035 22.615 0.000 ;
     END
   END OUT
   PIN PAD
@@ -196,7 +196,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 76.280 -2.035 76.920 0.020 ;
+        RECT 76.280 -2.035 76.920 0.000 ;
     END
   END PAD_A_ESD_0_H
   PIN PAD_A_ESD_1_H
@@ -204,7 +204,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 68.275 -2.035 68.925 0.235 ;
+        RECT 68.275 -2.035 68.925 0.000 ;
     END
   END PAD_A_ESD_1_H
   PIN PAD_A_NOESD_H
@@ -212,7 +212,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met3 ;
-        RECT 62.820 -2.035 63.890 7.670 ;
+        RECT 62.820 -2.035 63.890 0.000 ;
     END
   END PAD_A_NOESD_H
   PIN SLOW
@@ -236,7 +236,7 @@ MACRO sky130_ef_io__gpiov2_pad
     USE SIGNAL ;
     PORT
       LAYER met2 ;
-        RECT 79.715 -2.035 79.915 175.835 ;
+        RECT 79.715 -2.035 79.915 0.000 ;
     END
   END TIE_LO_ESD
   PIN VCCD

--- a/sky130/custom/sky130_fd_io/lib/sky130_ef_io__analog_stubs.lib
+++ b/sky130/custom/sky130_fd_io/lib/sky130_ef_io__analog_stubs.lib
@@ -1,0 +1,627 @@
+/**
+ * Copyright 2020 The SkyWater PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+library ("sky130_ef_io__analog_stubs") {
+  define(driver_model,library,string);
+  define(clk_width,library,string);
+  define(sim_opt,library,string);
+  define(simulator,library,string);
+  define(signal_voltage_type,pin,string);
+  technology ( cmos ) ;
+  delay_model : table_lookup;
+  revision : 1.0 ;
+  date : "Fri Oct 14 13:32:54 MST 2011";
+  voltage_unit  		: "1V"   ; 
+  current_unit  		: "1mA"  ;
+  leakage_power_unit		: "1nW"  ;
+  pulling_resistance_unit	: "1kohm" ;
+  time_unit			: "1ns"  ;
+  resistance_unit		: "1ohm" ;
+  capacitive_load_unit  	   (1,pf)  ;
+  
+  nom_process                   : 1.0 ;
+  nom_temperature               : 100	;
+  nom_voltage                   : 1.60	;
+
+  default_leakage_power_density : 0.0;
+  default_cell_leakage_power    : 0.0;
+  bus_naming_style              : "%s[%d]" ;
+  default_fanout_load	        : 0.0  ;  
+  default_inout_pin_cap 	: 0.0  ;  
+  default_input_pin_cap 	: 0.0  ;  
+  default_output_pin_cap	: 0.0  ;  
+  default_max_transition        : 25.00 ;
+  input_threshold_pct_rise      : 50.0 ;
+  input_threshold_pct_fall      : 50.0 ;
+  output_threshold_pct_rise     : 50.0 ;
+  output_threshold_pct_fall     : 50.0 ;
+  slew_lower_threshold_pct_fall : 20.0 ;
+  slew_lower_threshold_pct_rise : 20.0 ;
+  slew_upper_threshold_pct_fall : 80.0 ;
+  slew_upper_threshold_pct_rise : 80.0 ;
+  slew_derate_from_library 	:  1 ;
+  in_place_swap_mode            : match_footprint ;
+
+  library_features (report_delay_calculation);
+  define (always_on, pin, boolean) ;
+
+cell (sky130_ef_io__analog_esd_pad) {
+    cell_leakage_power :  2.9860000e+05 ;  
+    area :   14850.0 ;
+    pad_cell : true;
+
+    dont_touch : true ;      /* don't optimize this cell */
+is_macro_cell : true;
+    dont_use : true ;	     /* don't infer this cell	 */
+    interface_timing : true; /* this is a black box - a complex cell*/
+
+		pg_pin (VDDA) {
+			voltage_name : "VDDA";
+			pg_type : "primary_power";
+		}
+		pg_pin ("VDDIO_Q") {
+			voltage_name : "VDDIO_Q";
+			pg_type : "primary_power";
+		}
+		pg_pin (VSWITCH) {
+			voltage_name : "VSWITCH";
+			pg_type : "primary_power";
+		}
+		pg_pin (VDDIO) {
+			voltage_name : "VDDIO";
+			pg_type : "primary_power";
+		}
+		pg_pin (VCCD) {
+			voltage_name : "VCCD";
+			pg_type : "primary_power";
+		}
+		pg_pin (VCCHIB) {
+			voltage_name : "VCCHIB";
+			pg_type : "primary_power";
+		}
+		pg_pin (VSSD) {
+			voltage_name : "VSSD";
+			pg_type : "primary_ground";
+		}
+		pg_pin ("VSSIO_Q") {
+			voltage_name : "VSSIO_Q";
+			pg_type : "primary_ground";
+		}
+		pg_pin (VSSA) {
+			voltage_name : "VSSA";
+			pg_type : "primary_ground";
+		}
+		pg_pin (VSSIO) {
+			voltage_name : "VSSIO";
+			pg_type : "primary_ground";
+		}
+
+    pin (P_PAD) {
+    	    direction : "inout";
+    	    related_power_pin : "vddio";
+    	    related_ground_pin : "vssio";
+    	    always_on : false ;
+    	    is_pad : true;
+    	    capacitance : 1.061130;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+
+    pin (P_CORE) {
+    	    direction : "inout";
+    	    related_power_pin : "vddio";
+    	    related_ground_pin : "vssio";
+    	    always_on : false ;
+    	    is_pad : true;
+    	    capacitance : 1.061130;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+    pin ("AMUXBUS_A") {
+    	    direction : "inout";
+    	    related_power_pin : "VDDIO";
+    	    related_ground_pin : "VSSD";
+    	    always_on : true;
+    	    signal_voltage_type : "analog";
+    	    rise_capacitance : 0.069348;
+    	    capacitance : 0.070467;
+    	    fall_capacitance : 0.071586;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+    pin ("AMUXBUS_B") {
+    	    direction : "inout";
+    	    related_power_pin : "VDDIO";
+    	    related_ground_pin : "VSSD";
+    	    always_on : true;
+    	    signal_voltage_type : "analog";
+    	    rise_capacitance : 0.069348;
+    	    capacitance : 0.070467;
+    	    fall_capacitance : 0.071586;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+  }
+cell (sky130_ef_io__analog_minesd_pad) {
+    cell_leakage_power :  2.9860000e+05 ;  
+    area :   14850.0 ;
+    pad_cell : true;
+
+    dont_touch : true ;      /* don't optimize this cell */
+is_macro_cell : true;
+    dont_use : true ;	     /* don't infer this cell	 */
+    interface_timing : true; /* this is a black box - a complex cell*/
+
+		pg_pin (VDDA) {
+			voltage_name : "VDDA";
+			pg_type : "primary_power";
+		}
+		pg_pin ("VDDIO_Q") {
+			voltage_name : "VDDIO_Q";
+			pg_type : "primary_power";
+		}
+		pg_pin (VSWITCH) {
+			voltage_name : "VSWITCH";
+			pg_type : "primary_power";
+		}
+		pg_pin (VDDIO) {
+			voltage_name : "VDDIO";
+			pg_type : "primary_power";
+		}
+		pg_pin (VCCD) {
+			voltage_name : "VCCD";
+			pg_type : "primary_power";
+		}
+		pg_pin (VCCHIB) {
+			voltage_name : "VCCHIB";
+			pg_type : "primary_power";
+		}
+		pg_pin (VSSD) {
+			voltage_name : "VSSD";
+			pg_type : "primary_ground";
+		}
+		pg_pin ("VSSIO_Q") {
+			voltage_name : "VSSIO_Q";
+			pg_type : "primary_ground";
+		}
+		pg_pin (VSSA) {
+			voltage_name : "VSSA";
+			pg_type : "primary_ground";
+		}
+		pg_pin (VSSIO) {
+			voltage_name : "VSSIO";
+			pg_type : "primary_ground";
+		}
+
+    pin (P_PAD) {
+    	    direction : "inout";
+    	    related_power_pin : "vddio";
+    	    related_ground_pin : "vssio";
+    	    always_on : false ;
+    	    is_pad : true;
+    	    capacitance : 1.061130;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+
+    pin (P_CORE) {
+    	    direction : "inout";
+    	    related_power_pin : "vddio";
+    	    related_ground_pin : "vssio";
+    	    always_on : false ;
+    	    is_pad : true;
+    	    capacitance : 1.061130;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+    pin ("AMUXBUS_A") {
+    	    direction : "inout";
+    	    related_power_pin : "VDDIO";
+    	    related_ground_pin : "VSSD";
+    	    always_on : true;
+    	    signal_voltage_type : "analog";
+    	    rise_capacitance : 0.069348;
+    	    capacitance : 0.070467;
+    	    fall_capacitance : 0.071586;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+    pin ("AMUXBUS_B") {
+    	    direction : "inout";
+    	    related_power_pin : "VDDIO";
+    	    related_ground_pin : "VSSD";
+    	    always_on : true;
+    	    signal_voltage_type : "analog";
+    	    rise_capacitance : 0.069348;
+    	    capacitance : 0.070467;
+    	    fall_capacitance : 0.071586;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+  }
+cell (sky130_ef_io__analog_minesd_pad_short) {
+    cell_leakage_power :  2.9860000e+05 ;  
+    area :   14850.0 ;
+    pad_cell : true;
+
+    dont_touch : true ;      /* don't optimize this cell */
+is_macro_cell : true;
+    dont_use : true ;	     /* don't infer this cell	 */
+    interface_timing : true; /* this is a black box - a complex cell*/
+
+		pg_pin (VDDA) {
+			voltage_name : "VDDA";
+			pg_type : "primary_power";
+		}
+		pg_pin ("VDDIO_Q") {
+			voltage_name : "VDDIO_Q";
+			pg_type : "primary_power";
+		}
+		pg_pin (VSWITCH) {
+			voltage_name : "VSWITCH";
+			pg_type : "primary_power";
+		}
+		pg_pin (VDDIO) {
+			voltage_name : "VDDIO";
+			pg_type : "primary_power";
+		}
+		pg_pin (VCCD) {
+			voltage_name : "VCCD";
+			pg_type : "primary_power";
+		}
+		pg_pin (VCCHIB) {
+			voltage_name : "VCCHIB";
+			pg_type : "primary_power";
+		}
+		pg_pin (VSSD) {
+			voltage_name : "VSSD";
+			pg_type : "primary_ground";
+		}
+		pg_pin ("VSSIO_Q") {
+			voltage_name : "VSSIO_Q";
+			pg_type : "primary_ground";
+		}
+		pg_pin (VSSA) {
+			voltage_name : "VSSA";
+			pg_type : "primary_ground";
+		}
+		pg_pin (VSSIO) {
+			voltage_name : "VSSIO";
+			pg_type : "primary_ground";
+		}
+
+    pin (P_PAD) {
+    	    direction : "inout";
+    	    related_power_pin : "vddio";
+    	    related_ground_pin : "vssio";
+    	    always_on : false ;
+    	    is_pad : true;
+    	    capacitance : 1.061130;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+
+    pin (P_CORE) {
+    	    direction : "inout";
+    	    related_power_pin : "vddio";
+    	    related_ground_pin : "vssio";
+    	    always_on : false ;
+    	    is_pad : true;
+    	    capacitance : 1.061130;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+    pin ("AMUXBUS_A") {
+    	    direction : "inout";
+    	    related_power_pin : "VDDIO";
+    	    related_ground_pin : "VSSD";
+    	    always_on : true;
+    	    signal_voltage_type : "analog";
+    	    rise_capacitance : 0.069348;
+    	    capacitance : 0.070467;
+    	    fall_capacitance : 0.071586;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+    pin ("AMUXBUS_B") {
+    	    direction : "inout";
+    	    related_power_pin : "VDDIO";
+    	    related_ground_pin : "VSSD";
+    	    always_on : true;
+    	    signal_voltage_type : "analog";
+    	    rise_capacitance : 0.069348;
+    	    capacitance : 0.070467;
+    	    fall_capacitance : 0.071586;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+  }
+cell (sky130_ef_io__analog_noesd_pad) {
+    cell_leakage_power :  2.9860000e+05 ;  
+    area :   14850.0 ;
+    pad_cell : true;
+
+    dont_touch : true ;      /* don't optimize this cell */
+is_macro_cell : true;
+    dont_use : true ;	     /* don't infer this cell	 */
+    interface_timing : true; /* this is a black box - a complex cell*/
+
+		pg_pin (VDDA) {
+			voltage_name : "VDDA";
+			pg_type : "primary_power";
+		}
+		pg_pin ("VDDIO_Q") {
+			voltage_name : "VDDIO_Q";
+			pg_type : "primary_power";
+		}
+		pg_pin (VSWITCH) {
+			voltage_name : "VSWITCH";
+			pg_type : "primary_power";
+		}
+		pg_pin (VDDIO) {
+			voltage_name : "VDDIO";
+			pg_type : "primary_power";
+		}
+		pg_pin (VCCD) {
+			voltage_name : "VCCD";
+			pg_type : "primary_power";
+		}
+		pg_pin (VCCHIB) {
+			voltage_name : "VCCHIB";
+			pg_type : "primary_power";
+		}
+		pg_pin (VSSD) {
+			voltage_name : "VSSD";
+			pg_type : "primary_ground";
+		}
+		pg_pin ("VSSIO_Q") {
+			voltage_name : "VSSIO_Q";
+			pg_type : "primary_ground";
+		}
+		pg_pin (VSSA) {
+			voltage_name : "VSSA";
+			pg_type : "primary_ground";
+		}
+		pg_pin (VSSIO) {
+			voltage_name : "VSSIO";
+			pg_type : "primary_ground";
+		}
+
+    pin (P_PAD) {
+    	    direction : "inout";
+    	    related_power_pin : "vddio";
+    	    related_ground_pin : "vssio";
+    	    always_on : false ;
+    	    is_pad : true;
+    	    capacitance : 1.061130;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+
+    pin (P_CORE) {
+    	    direction : "inout";
+    	    related_power_pin : "vddio";
+    	    related_ground_pin : "vssio";
+    	    always_on : false ;
+    	    is_pad : true;
+    	    capacitance : 1.061130;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+    pin ("AMUXBUS_A") {
+    	    direction : "inout";
+    	    related_power_pin : "VDDIO";
+    	    related_ground_pin : "VSSD";
+    	    always_on : true;
+    	    signal_voltage_type : "analog";
+    	    rise_capacitance : 0.069348;
+    	    capacitance : 0.070467;
+    	    fall_capacitance : 0.071586;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+    pin ("AMUXBUS_B") {
+    	    direction : "inout";
+    	    related_power_pin : "VDDIO";
+    	    related_ground_pin : "VSSD";
+    	    always_on : true;
+    	    signal_voltage_type : "analog";
+    	    rise_capacitance : 0.069348;
+    	    capacitance : 0.070467;
+    	    fall_capacitance : 0.071586;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+  }
+cell (sky130_ef_io__analog_pad) {
+    cell_leakage_power :  2.9860000e+05 ;  
+    area :   14850.0 ;
+    pad_cell : true;
+
+    dont_touch : true ;      /* don't optimize this cell */
+is_macro_cell : true;
+    dont_use : true ;	     /* don't infer this cell	 */
+    interface_timing : true; /* this is a black box - a complex cell*/
+
+		pg_pin (VDDA) {
+			voltage_name : "VDDA";
+			pg_type : "primary_power";
+		}
+		pg_pin ("VDDIO_Q") {
+			voltage_name : "VDDIO_Q";
+			pg_type : "primary_power";
+		}
+		pg_pin (VSWITCH) {
+			voltage_name : "VSWITCH";
+			pg_type : "primary_power";
+		}
+		pg_pin (VDDIO) {
+			voltage_name : "VDDIO";
+			pg_type : "primary_power";
+		}
+		pg_pin (VCCD) {
+			voltage_name : "VCCD";
+			pg_type : "primary_power";
+		}
+		pg_pin (VCCHIB) {
+			voltage_name : "VCCHIB";
+			pg_type : "primary_power";
+		}
+		pg_pin (VSSD) {
+			voltage_name : "VSSD";
+			pg_type : "primary_ground";
+		}
+		pg_pin ("VSSIO_Q") {
+			voltage_name : "VSSIO_Q";
+			pg_type : "primary_ground";
+		}
+		pg_pin (VSSA) {
+			voltage_name : "VSSA";
+			pg_type : "primary_ground";
+		}
+		pg_pin (VSSIO) {
+			voltage_name : "VSSIO";
+			pg_type : "primary_ground";
+		}
+
+    pin (P_PAD) {
+    	    direction : "inout";
+    	    related_power_pin : "vddio";
+    	    related_ground_pin : "vssio";
+    	    always_on : false ;
+    	    is_pad : true;
+    	    capacitance : 1.061130;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+
+    pin (P_CORE) {
+    	    direction : "inout";
+    	    related_power_pin : "vddio";
+    	    related_ground_pin : "vssio";
+    	    always_on : false ;
+    	    is_pad : true;
+    	    capacitance : 1.061130;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+    pin ("AMUXBUS_A") {
+    	    direction : "inout";
+    	    related_power_pin : "VDDIO";
+    	    related_ground_pin : "VSSD";
+    	    always_on : true;
+    	    signal_voltage_type : "analog";
+    	    rise_capacitance : 0.069348;
+    	    capacitance : 0.070467;
+    	    fall_capacitance : 0.071586;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+    pin ("AMUXBUS_B") {
+    	    direction : "inout";
+    	    related_power_pin : "VDDIO";
+    	    related_ground_pin : "VSSD";
+    	    always_on : true;
+    	    signal_voltage_type : "analog";
+    	    rise_capacitance : 0.069348;
+    	    capacitance : 0.070467;
+    	    fall_capacitance : 0.071586;
+        ccsn_first_stage() { 
+            is_needed : false ; 
+        } 
+        ccsn_last_stage() { 
+            is_needed : false ; 
+        } 
+    }
+  }
+}

--- a/sky130/librelane/config.tcl
+++ b/sky130/librelane/config.tcl
@@ -70,6 +70,7 @@ set ::env(PAD_LEFS) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lef/sky1
 set ::env(PAD_GDS) "\
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/gds/sky130_fd_io.gds\
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/gds/sky130_ef_io.gds\
+    $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/gds/sky130_ef_io__analog.gds\
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/gds/sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um.gds\
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/gds/sky130_ef_io__connect_vdda_vddio_and_vssa_vssio_slice_20um.gds\
 "

--- a/sky130/librelane/sky130_ef_io/config.tcl
+++ b/sky130/librelane/sky130_ef_io/config.tcl
@@ -32,6 +32,7 @@ dict set ::env(PAD_LIBS) "*_tt_025C_1v80" "\
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__vssio_hvc_clamped_pad_tt_025C_1v80_3v30_3v30.lib \
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_tt_tt_025C_1v80_3v30.lib \
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/slices_stubs.lib \
+    $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__analog_stubs.lib \
 "
 dict set ::env(PAD_LIBS) "*_ff_n40C_1v95" "\
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__vccd_lvc_clamped_pad_ff_n40C_1v95_5v50_5v50.lib \
@@ -40,6 +41,7 @@ dict set ::env(PAD_LIBS) "*_ff_n40C_1v95" "\
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__vssio_hvc_clamped_pad_ff_n40C_1v95_5v50_5v50.lib \
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_ff_ff_n40C_1v95_5v50.lib \
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/slices_stubs.lib \
+    $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__analog_stubs.lib \
 "
 dict set ::env(PAD_LIBS) "*_ss_100C_1v60" "\
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__vccd_lvc_clamped_pad_ss_100C_1v60_3v00_3v00.lib \
@@ -48,6 +50,7 @@ dict set ::env(PAD_LIBS) "*_ss_100C_1v60" "\
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__vssio_hvc_clamped_pad_ss_100C_1v60_3v00_3v00.lib \
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__gpiov2_pad_ss_ss_100C_1v60_3v00.lib \
     $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/slices_stubs.lib \
+    $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_io/lib/sky130_ef_io__analog_stubs.lib \
 "
 
 # Pad bondpad information (if needed)
@@ -64,6 +67,11 @@ set ::env(PAD_PLACE_IO_TERMINALS) "\
     sky130_ef_io__vssd_lvc_clamped_pad/VSSD_PAD\
     sky130_ef_io__vddio_hvc_clamped_pad/VDDIO_PAD\
     sky130_ef_io__vssio_hvc_clamped_pad/VSSIO_PAD\
+    sky130_ef_io__analog_esd_pad/P_PAD\
+    sky130_ef_io__analog_minesd_pad/P_PAD\
+    sky130_ef_io__analog_minesd_pad_short/P_PAD\
+    sky130_ef_io__analog_noesd_pad/P_PAD\
+    sky130_ef_io__analog_pad/P_PAD\
 "
 
 # Sealring is added afterwards


### PR DESCRIPTION
This PR makes slight adjustments to the LEF of sky130_ef_io__gpiov2_pad, so that the pins are only located at the core side.

You can see the issue here:

<img width="1733" height="962" alt="Bildschirmfoto vom 2026-04-30 11-53-17" src="https://github.com/user-attachments/assets/5f53f8a3-db34-4a32-9a91-56361a9f0c0c" />


The physical pin for `IN` runs along the entire the side of the I/O pad. OpenROAD creates access points everywhere on the pin, which can lead to DRT getting confused during routing.

Therefore, in this PR, I capped the pin shapes of all signal pins to 0. This way, access points will only be created where it makes sense (near the core side). This seems to work much better in practice than having these long pins.

Note: I opened this PR so that I wouldn't forget about it, but it can wait until after Latch-Up.