### PR TITLE
sky130: updated variables in CSL config.tcl files

### DIFF
--- a/sky130/librelane/sky130_fd_sc_hd/config.tcl
+++ b/sky130/librelane/sky130_fd_sc_hd/config.tcl
@@ -10,49 +10,40 @@ set ::env(SYNTH_MUX_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/librelane/$::en
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unithd"
-set ::env(PLACE_SITE_WIDTH) 0.460
-set ::env(PLACE_SITE_HEIGHT) 2.720
 
 # welltap and endcap cells
-set ::env(FP_WELLTAP_CELL) "sky130_fd_sc_hd__tapvpwrvgnd_1"
-set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_hd__decap_3"
+set ::env(WELLTAP_CELL) "sky130_fd_sc_hd__tapvpwrvgnd_1"
+set ::env(ENDCAP_CELL) "sky130_fd_sc_hd__decap_3"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hd__inv_2"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hd__inv_2/Y"
 #capacitance : 0.017653;
-set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
+#set ::env(SYNTH_CLK_DRIVING_CELL) "sky130_fd_sc_hd__clkinv_2/Y"
 # update these
 set ::env(OUTPUT_CAP_LOAD) "33.442" ; # femtofarad __inv_16 pin A cap (https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hd/blob/main/cells/inv/sky130_fd_sc_hd__inv_16__tt_025C_1v80.lib.json)
-set ::env(SYNTH_MIN_BUF_PORT) "sky130_fd_sc_hd__buf_2 A X"
-set ::env(SYNTH_TIEHI_PORT) "sky130_fd_sc_hd__conb_1 HI"
-set ::env(SYNTH_TIELO_PORT) "sky130_fd_sc_hd__conb_1 LO"
+set ::env(SYNTH_BUFFER_CELL) "sky130_fd_sc_hd__buf_2/A/X"
+set ::env(SYNTH_TIEHI_CELL) "sky130_fd_sc_hd__conb_1/HI"
+set ::env(SYNTH_TIELO_CELL) "sky130_fd_sc_hd__conb_1/LO"
 
 # cts defaults
 set ::env(CTS_ROOT_BUFFER) sky130_fd_sc_hd__clkbuf_16
-set ::env(CELL_CLK_PORT) CLK
 
-# Fillcell insertion
-set ::env(FILL_CELL) "sky130_fd_sc_hd__fill_2 sky130_fd_sc_hd__fill_1"
-set ::env(DECAP_CELL) "sky130_fd_sc_hd__decap_3"
-set ::env(RE_BUFFER_CELL) "sky130_fd_sc_hd__buf_4"
+# fill/decap cell insertion
+set ::env(FILL_CELLS) "sky130_fd_sc_hd__fill_2 sky130_fd_sc_hd__fill_1"
+set ::env(DECAP_CELLS) "sky130_fd_sc_hd__decap_3"
 
-# Diode insertaion
-set ::env(DIODE_CELL) "sky130_fd_sc_hd__diode_2"
-set ::env(FAKEDIODE_CELL) "sky130_ef_sc_hd__fakediode_2"
-set ::env(DIODE_CELL_PIN) "DIODE"
+# diode insertion
+set ::env(DIODE_CELL) "sky130_fd_sc_hd__diode_2/DIODE"
 
 set ::env(GPL_CELL_PADDING) {0}
 set ::env(DPL_CELL_PADDING) {0}
 set ::env(CELL_PAD_EXCLUDE) "sky130_fd_sc_hd__tap* sky130_fd_sc_hd__decap* sky130_ef_sc_hd__decap* sky130_fd_sc_hd__fill*"
 
 # Clk Buffers info CTS data
-set ::env(ROOT_CLK_BUFFER) sky130_fd_sc_hd__clkbuf_16
-set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hd__clkbuf_8 sky130_fd_sc_hd__clkbuf_4 sky130_fd_sc_hd__clkbuf_2"
-set ::env(FP_PDN_RAIL_WIDTH) 0.48
-# Determined from https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hd/blob/ac7fb61f06e6470b94e8afdf7c25268f62fbd7b1/cells/clkbuf/sky130_fd_sc_hd__clkbuf_16__tt_025C_1v80.lib.json
-set ::env(CTS_MAX_CAP) 1.53169
+set ::env(CTS_CLK_BUFFERS) "sky130_fd_sc_hd__clkbuf_8 sky130_fd_sc_hd__clkbuf_4 sky130_fd_sc_hd__clkbuf_2"
+set ::env(PDN_RAIL_WIDTH) 0.48
 set ::env(MAX_TRANSITION_CONSTRAINT) 0.75
 set ::env(MAX_FANOUT_CONSTRAINT) 10
 set ::env(MAX_CAPACITANCE_CONSTRAINT) 0.2
 
-set ::env(TRISTATE_CELL_PREFIX) "$::env(STD_CELL_LIBRARY)__ebuf"
+set ::env(TRISTATE_CELLS) "$::env(STD_CELL_LIBRARY)__ebuf*"

--- a/sky130/librelane/sky130_fd_sc_hdll/config.tcl
+++ b/sky130/librelane/sky130_fd_sc_hdll/config.tcl
@@ -7,49 +7,40 @@ set ::env(SYNTH_MUX_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/librelane/$::en
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unithd"
-set ::env(PLACE_SITE_WIDTH) 0.460
-set ::env(PLACE_SITE_HEIGHT) 2.720
 
 # welltap and endcap cells
-set ::env(FP_WELLTAP_CELL) "sky130_fd_sc_hdll__tapvpwrvgnd_1"
-set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_hdll__decap_3"
+set ::env(WELLTAP_CELL) "sky130_fd_sc_hdll__tapvpwrvgnd_1"
+set ::env(ENDCAP_CELL) "sky130_fd_sc_hdll__decap_3"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hdll__inv_2"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hdll__inv_2/Y"
 #capacitance : 0.017653;
-set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
+#set ::env(SYNTH_CLK_DRIVING_CELL) "sky130_fd_sc_hdll__clkinv_2/Y"
 # update these
 set ::env(OUTPUT_CAP_LOAD) "33.468" ; # femtofarad _inv_16 pin A cap (https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hdll/blob/main/cells/inv/sky130_fd_sc_hdll__inv_16__tt_025C_1v80.lib.json)
-set ::env(SYNTH_MIN_BUF_PORT) "sky130_fd_sc_hdll__buf_2 A X"
-set ::env(SYNTH_TIEHI_PORT) "sky130_fd_sc_hdll__conb_1 HI"
-set ::env(SYNTH_TIELO_PORT) "sky130_fd_sc_hdll__conb_1 LO"
+set ::env(SYNTH_BUFFER_CELL) "sky130_fd_sc_hdll__buf_2/A/X"
+set ::env(SYNTH_TIEHI_CELL) "sky130_fd_sc_hdll__conb_1/HI"
+set ::env(SYNTH_TIELO_CELL) "sky130_fd_sc_hdll__conb_1/LO"
 
 # cts defaults
 set ::env(CTS_ROOT_BUFFER) sky130_fd_sc_hdll__clkbuf_16
-set ::env(CELL_CLK_PORT) CLK
 
-# Fillcell insertion
-set ::env(FILL_CELL) "sky130_fd_sc_hdll__fill*"
-set ::env(DECAP_CELL) "sky130_fd_sc_hdll__decap*"
-set ::env(RE_BUFFER_CELL) "sky130_fd_sc_hdll__buf_4"
+# fill/decap cell insertion
+set ::env(FILL_CELLS) "sky130_fd_sc_hdll__fill*"
+set ::env(DECAP_CELLS) "sky130_fd_sc_hdll__decap*"
 
-# Diode insertaion
-set ::env(DIODE_CELL) "sky130_fd_sc_hdll__diode_2"
-set ::env(FAKEDIODE_CELL) "sky130_fd_sc_hdll__fakediode_2"
-set ::env(DIODE_CELL_PIN) "DIODE"
+# diode insertion
+set ::env(DIODE_CELL) "sky130_fd_sc_hdll__diode_2/DIODE"
 
 set ::env(GPL_CELL_PADDING) {0}
 set ::env(DPL_CELL_PADDING) {0}
 set ::env(CELL_PAD_EXCLUDE) "$::env(STD_CELL_LIBRARY)__tap* $::env(STD_CELL_LIBRARY)__decap* $::env(STD_CELL_LIBRARY)__fill*"
 
 # Clk Buffers info CTS data
-set ::env(ROOT_CLK_BUFFER) $::env(STD_CELL_LIBRARY)__clkbuf_16
-set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hdll__clkbuf_8 sky130_fd_sc_hdll__clkbuf_4 sky130_fd_sc_hdll__clkbuf_2"
-set ::env(FP_PDN_RAIL_WIDTH) 0.48
-# Determined from https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hdll/blob/0694bd23893de20f5233ef024acf6cca1e750ac6/cells/clkbuf/sky130_fd_sc_hdll__clkbuf_16__tt_025C_1v80.lib.json
-set ::env(CTS_MAX_CAP) 1.03547
+set ::env(CTS_CLK_BUFFERS) "sky130_fd_sc_hdll__clkbuf_8 sky130_fd_sc_hdll__clkbuf_4 sky130_fd_sc_hdll__clkbuf_2"
+set ::env(PDN_RAIL_WIDTH) 0.48
 set ::env(MAX_TRANSITION_CONSTRAINT) 0.75
 set ::env(MAX_FANOUT_CONSTRAINT) 10
 set ::env(MAX_CAPACITANCE_CONSTRAINT) 0.2
 
-set ::env(TRISTATE_CELL_PREFIX) "$::env(STD_CELL_LIBRARY)__ebuf"
+set ::env(TRISTATE_CELLS) "$::env(STD_CELL_LIBRARY)__ebuf*"

--- a/sky130/librelane/sky130_fd_sc_hs/config.tcl
+++ b/sky130/librelane/sky130_fd_sc_hs/config.tcl
@@ -10,45 +10,39 @@ set ::env(SYNTH_MUX_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/librelane/$::en
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unit"
-set ::env(PLACE_SITE_WIDTH) 0.480
-set ::env(PLACE_SITE_HEIGHT) 3.330
 
 # welltap and endcap cells
-set ::env(FP_WELLTAP_CELL) "sky130_fd_sc_hs__tapvpwrvgnd_1"
-set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_hs__decap_4"
+set ::env(WELLTAP_CELL) "sky130_fd_sc_hs__tapvpwrvgnd_1"
+set ::env(ENDCAP_CELL) "sky130_fd_sc_hs__decap_4"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hs__inv_2"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hs__inv_2/Y"
 #capacitance : 0.02104;
-set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
+#set ::env(SYNTH_CLK_DRIVING_CELL) "sky130_fd_sc_hs__clkinv_2/Y"
 # update these
 set ::env(OUTPUT_CAP_LOAD) "43.39" ; # femtofarad _inv_16 pin A cap (https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hs/blob/main/cells/inv/sky130_fd_sc_hs__inv_16__tt_025C_1v68.lib.json)
-set ::env(SYNTH_MIN_BUF_PORT) "sky130_fd_sc_hs__buf_2 A X"
-set ::env(SYNTH_TIEHI_PORT) "sky130_fd_sc_hs__conb_1 HI"
-set ::env(SYNTH_TIELO_PORT) "sky130_fd_sc_hs__conb_1 LO"
+set ::env(SYNTH_BUFFER_CELL) "sky130_fd_sc_hs__buf_2/A/X"
+set ::env(SYNTH_TIEHI_CELL) "sky130_fd_sc_hs__conb_1/HI"
+set ::env(SYNTH_TIELO_CELL) "sky130_fd_sc_hs__conb_1/LO"
 
 # cts defaults
 set ::env(CTS_ROOT_BUFFER) sky130_fd_sc_hs__clkbuf_16
-set ::env(CELL_CLK_PORT) CLK
 
-# Fillcell insertion
-set ::env(FILL_CELL) "sky130_fd_sc_hs__fill*"
-set ::env(DECAP_CELL) "sky130_fd_sc_hs__decap_4"
+# fill/decap cell insertion
+set ::env(FILL_CELLS) "sky130_fd_sc_hs__fill*"
+set ::env(DECAP_CELLS) "sky130_fd_sc_hs__decap_4"
 
-# Diode insertaion
-set ::env(DIODE_CELL) "sky130_fd_sc_hs__diode_2"
-set ::env(DIODE_CELL_PIN) "DIODE"
+# diode insertion
+set ::env(DIODE_CELL) "sky130_fd_sc_hs__diode_2/DIODE"
 
 set ::env(GPL_CELL_PADDING) {0}
 set ::env(DPL_CELL_PADDING) {0}
 set ::env(CELL_PAD_EXCLUDE) "sky130_fd_sc_hs__tap* sky130_fd_sc_hs__decap* sky130_fd_sc_hs__fill*"
 
-set ::env(ROOT_CLK_BUFFER) sky130_fd_sc_hs__clkbuf_16
-set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hs__clkbuf_8 sky130_fd_sc_hs__clkbuf_4 sky130_fd_sc_hs__clkbuf_2"
-set ::env(CTS_MAX_CAP) 1.8894300000
+set ::env(CTS_CLK_BUFFERS) "sky130_fd_sc_hs__clkbuf_8 sky130_fd_sc_hs__clkbuf_4 sky130_fd_sc_hs__clkbuf_2"
 set ::env(MAX_TRANSITION_CONSTRAINT) 0.75
 set ::env(MAX_FANOUT_CONSTRAINT) 10
 set ::env(MAX_CAPACITANCE_CONSTRAINT) 0.2
-set ::env(FP_PDN_RAIL_WIDTH) 0.48
+set ::env(PDN_RAIL_WIDTH) 0.48
 
-set ::env(TRISTATE_CELL_PREFIX) "$::env(STD_CELL_LIBRARY)__ebuf"
+set ::env(TRISTATE_CELLS) "$::env(STD_CELL_LIBRARY)__ebuf*"

--- a/sky130/librelane/sky130_fd_sc_hvl/config.tcl
+++ b/sky130/librelane/sky130_fd_sc_hvl/config.tcl
@@ -40,45 +40,37 @@ set ::env(SYNTH_MUX_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/librelane/$::en
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unithv"
-set ::env(PLACE_SITE_WIDTH) 0.480
-set ::env(PLACE_SITE_HEIGHT) 4.070
 
 # welltap and endcap cells
-#set ::env(FP_WELLTAP_CELL) ""
-set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_hvl__decap_4"
+#set ::env(WELLTAP_CELL) ""
+set ::env(ENDCAP_CELL) "sky130_fd_sc_hvl__decap_4"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hvl__inv_2"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_hvl__inv_2/Y"
 #capacitance : 0.017653;
-set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
 # update these
 set ::env(OUTPUT_CAP_LOAD) "70.77" ; # femtofarad __inv_16 pin A cap (https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hvl/blob/main/cells/inv/sky130_fd_sc_hvl__inv_16__tt_025C_3v30.lib.json)
-set ::env(SYNTH_MIN_BUF_PORT) "sky130_fd_sc_hvl__buf_1 A X"
-set ::env(SYNTH_TIEHI_PORT) "sky130_fd_sc_hvl__conb_1 HI"
-set ::env(SYNTH_TIELO_PORT) "sky130_fd_sc_hvl__conb_1 LO"
+set ::env(SYNTH_BUFFER_CELL) "sky130_fd_sc_hvl__buf_1/A/X"
+set ::env(SYNTH_TIEHI_CELL) "sky130_fd_sc_hvl__conb_1/HI"
+set ::env(SYNTH_TIELO_CELL) "sky130_fd_sc_hvl__conb_1/LO"
 
 # cts defaults
 set ::env(CTS_ROOT_BUFFER) sky130_fd_sc_hvl__buf_16
-set ::env(CELL_CLK_PORT) CLK
 
-# Fillcell insertion
-set ::env(FILL_CELL) "sky130_fd_sc_hvl__fill*"
-set ::env(DECAP_CELL) "sky130_fd_sc_hvl__decap*"
-set ::env(RE_BUFFER_CELL) "sky130_fd_sc_hvl__buf_1"
+# fill/decap cell insertion
+set ::env(FILL_CELLS) "sky130_fd_sc_hvl__fill*"
+set ::env(DECAP_CELLS) "sky130_fd_sc_hvl__decap*"
 
-# Diode insertaion
-set ::env(DIODE_CELL) "sky130_fd_sc_hvl__diode_2"
-set ::env(DIODE_CELL_PIN) "DIODE"
+# diode insertion
+set ::env(DIODE_CELL) "sky130_fd_sc_hvl__diode_2/DIODE"
 
 set ::env(GPL_CELL_PADDING) {0}
 set ::env(DPL_CELL_PADDING) {0}
 set ::env(CELL_PAD_EXCLUDE) "sky130_fd_sc_hvl__tap* sky130_fd_sc_hvl__decap* sky130_fd_sc_hvl__fill*"
 
 # Clk Buffers info CTS data
-set ::env(ROOT_CLK_BUFFER) sky130_fd_sc_hvl__buf_16
-set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_hvl__buf_8 sky130_fd_sc_hvl__buf_4 sky130_fd_sc_hvl__buf_2"
-set ::env(CTS_MAX_CAP) 5.57100
+set ::env(CTS_CLK_BUFFERS) "sky130_fd_sc_hvl__buf_8 sky130_fd_sc_hvl__buf_4 sky130_fd_sc_hvl__buf_2"
 set ::env(MAX_TRANSITION_CONSTRAINT) 0.75
 set ::env(MAX_FANOUT_CONSTRAINT) 10
 set ::env(MAX_CAPACITANCE_CONSTRAINT) 0.2
-set ::env(FP_PDN_RAIL_WIDTH) 0.51
+set ::env(PDN_RAIL_WIDTH) 0.51

--- a/sky130/librelane/sky130_fd_sc_ls/config.tcl
+++ b/sky130/librelane/sky130_fd_sc_ls/config.tcl
@@ -10,48 +10,40 @@ set ::env(SYNTH_MUX_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/librelane/$::en
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unit"
-set ::env(PLACE_SITE_WIDTH) 0.480
-set ::env(PLACE_SITE_HEIGHT) 3.330
 
 # welltap and endcap cells
-set ::env(FP_WELLTAP_CELL) "sky130_fd_sc_ls__tapvpwrvgnd_1"
-set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_ls__decap_4"
+set ::env(WELLTAP_CELL) "sky130_fd_sc_ls__tapvpwrvgnd_1"
+set ::env(ENDCAP_CELL) "sky130_fd_sc_ls__decap_4"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_ls__inv_2"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_ls__inv_2/Y"
 #capacitance : 0.017653;
-set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
+#set ::env(SYNTH_CLK_DRIVING_CELL) "sky130_fd_sc_ls__clkinv_2/Y"
 # update these
 set ::env(OUTPUT_CAP_LOAD) "46.690" ; # femtofarad _inv_16 pin A cap (https://github.com/google/skywater-pdk-libs-sky130_fd_sc_ls/blob/main/cells/inv/sky130_fd_sc_ls__inv_16__tt_100C_1v80.lib.json)
-set ::env(SYNTH_MIN_BUF_PORT) "sky130_fd_sc_ls__buf_2 A X"
-set ::env(SYNTH_TIEHI_PORT) "sky130_fd_sc_ls__conb_1 HI"
-set ::env(SYNTH_TIELO_PORT) "sky130_fd_sc_ls__conb_1 LO"
+set ::env(SYNTH_BUFFER_CELL) "sky130_fd_sc_ls__buf_2/A/X"
+set ::env(SYNTH_TIEHI_CELL) "sky130_fd_sc_ls__conb_1/HI"
+set ::env(SYNTH_TIELO_CELL) "sky130_fd_sc_ls__conb_1/LO"
 
 # cts defaults
 set ::env(CTS_ROOT_BUFFER) sky130_fd_sc_ls__clkbuf_16
-set ::env(CELL_CLK_PORT) CLK
 
-# Fillcell insertion
-set ::env(FILL_CELL) "sky130_fd_sc_ls__fill*"
-set ::env(DECAP_CELL) "sky130_fd_sc_ls__decap*"
-set ::env(RE_BUFFER_CELL) "sky130_fd_sc_ls__buf_4"
+# fill/decap cell insertion
+set ::env(FILL_CELLS) "sky130_fd_sc_ls__fill*"
+set ::env(DECAP_CELLS) "sky130_fd_sc_ls__decap*"
 
-# Diode insertaion
-set ::env(DIODE_CELL) "sky130_fd_sc_ls__diode_2"
-set ::env(FAKEDIODE_CELL) "sky130_fd_sc_ls__fakediode_2"
-set ::env(DIODE_CELL_PIN) "DIODE"
+# diode insertion
+set ::env(DIODE_CELL) "sky130_fd_sc_ls__diode_2/DIODE"
 
 set ::env(GPL_CELL_PADDING) {0}
 set ::env(DPL_CELL_PADDING) {0}
 set ::env(CELL_PAD_EXCLUDE) "$::env(STD_CELL_LIBRARY)__tap* $::env(STD_CELL_LIBRARY)__decap* $::env(STD_CELL_LIBRARY)__fill*"
 
 # Clk Buffers info CTS data
-set ::env(ROOT_CLK_BUFFER) $::env(STD_CELL_LIBRARY)__clkbuf_16
-set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_ls__clkbuf_8 sky130_fd_sc_ls__clkbuf_4 sky130_fd_sc_ls__clkbuf_2"
-set ::env(CTS_MAX_CAP) 1.53169
+set ::env(CTS_CLK_BUFFERS) "sky130_fd_sc_ls__clkbuf_8 sky130_fd_sc_ls__clkbuf_4 sky130_fd_sc_ls__clkbuf_2"
 set ::env(MAX_TRANSITION_CONSTRAINT) 0.75
 set ::env(MAX_FANOUT_CONSTRAINT) 10
 set ::env(MAX_CAPACITANCE_CONSTRAINT) 0.2
-set ::env(FP_PDN_RAIL_WIDTH) 0.48
+set ::env(PDN_RAIL_WIDTH) 0.48
 
-set ::env(TRISTATE_CELL_PREFIX) "$::env(STD_CELL_LIBRARY)__ebuf"
+set ::env(TRISTATE_CELLS) "$::env(STD_CELL_LIBRARY)__ebuf*"

--- a/sky130/librelane/sky130_fd_sc_ms/config.tcl
+++ b/sky130/librelane/sky130_fd_sc_ms/config.tcl
@@ -10,47 +10,40 @@ set ::env(SYNTH_MUX_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/librelane/$::en
 # Placement site for core cells
 # This can be found in the technology lef
 set ::env(PLACE_SITE) "unit"
-set ::env(PLACE_SITE_WIDTH) 0.480
-set ::env(PLACE_SITE_HEIGHT) 3.330
 
 # welltap and endcap cells
-set ::env(FP_WELLTAP_CELL) "sky130_fd_sc_ms__tapvpwrvgnd_1"
-set ::env(FP_ENDCAP_CELL) "sky130_fd_sc_ms__decap_4"
+set ::env(WELLTAP_CELL) "sky130_fd_sc_ms__tapvpwrvgnd_1"
+set ::env(ENDCAP_CELL) "sky130_fd_sc_ms__decap_4"
 
 # defaults (can be overridden by designs):
-set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_ms__inv_2"
+set ::env(SYNTH_DRIVING_CELL) "sky130_fd_sc_ms__inv_2/Y"
 #capacitance : 0.017653;
-set ::env(SYNTH_DRIVING_CELL_PIN) "Y"
+#set ::env(SYNTH_CLK_DRIVING_CELL) "sky130_fd_sc_ms__clkinv_2/Y"
 # update these
 set ::env(OUTPUT_CAP_LOAD) "22.66" ; # femtofarad _inv_8 pin A cap
-set ::env(SYNTH_MIN_BUF_PORT) "sky130_fd_sc_ms__buf_2 A X"
-set ::env(SYNTH_TIEHI_PORT) "sky130_fd_sc_ms__conb_1 HI"
-set ::env(SYNTH_TIELO_PORT) "sky130_fd_sc_ms__conb_1 LO"
+set ::env(SYNTH_BUFFER_CELL) "sky130_fd_sc_ms__buf_2/A/X"
+set ::env(SYNTH_TIEHI_CELL) "sky130_fd_sc_ms__conb_1/HI"
+set ::env(SYNTH_TIELO_CELL) "sky130_fd_sc_ms__conb_1/LO"
 
 # cts defaults
 set ::env(CTS_ROOT_BUFFER) sky130_fd_sc_ms__clkbuf_16
-set ::env(CELL_CLK_PORT) CLK
 
-# Fillcell insertion
-set ::env(FILL_CELL) "sky130_fd_sc_ms__fill*"
-set ::env(DECAP_CELL) "sky130_fd_sc_ms__decap_4"
-set ::env(RE_BUFFER_CELL) "sky130_fd_sc_ms__buf_4"
+# fill/decap cell insertion
+set ::env(FILL_CELLS) "sky130_fd_sc_ms__fill*"
+set ::env(DECAP_CELLS) "sky130_fd_sc_ms__decap_4"
 
-# Diode insertaion
-set ::env(DIODE_CELL) "sky130_fd_sc_ms__diode_2"
-set ::env(DIODE_CELL_PIN) "DIODE"
+# diode insertion
+set ::env(DIODE_CELL) "sky130_fd_sc_ms__diode_2/DIODE"
 
 set ::env(GPL_CELL_PADDING) {0}
 set ::env(DPL_CELL_PADDING) {0}
 set ::env(CELL_PAD_EXCLUDE) "$::env(STD_CELL_LIBRARY)__tap* $::env(STD_CELL_LIBRARY)__decap* $::env(STD_CELL_LIBRARY)__fill*"
 
 # Clk Buffers info CTS data
-set ::env(ROOT_CLK_BUFFER) $::env(STD_CELL_LIBRARY)__clkbuf_16
-set ::env(CTS_CLK_BUFFER_LIST) "sky130_fd_sc_ms__clkbuf_8 sky130_fd_sc_ms__clkbuf_4 sky130_fd_sc_ms__clkbuf_2"
-set ::env(CTS_MAX_CAP) 1.53169
+set ::env(CTS_CLK_BUFFERS) "sky130_fd_sc_ms__clkbuf_8 sky130_fd_sc_ms__clkbuf_4 sky130_fd_sc_ms__clkbuf_2"
 set ::env(MAX_TRANSITION_CONSTRAINT) 0.75
 set ::env(MAX_FANOUT_CONSTRAINT) 10
 set ::env(MAX_CAPACITANCE_CONSTRAINT) 0.2
-set ::env(FP_PDN_RAIL_WIDTH) 0.48
+set ::env(PDN_RAIL_WIDTH) 0.48
 
-set ::env(TRISTATE_CELL_PREFIX) "$::env(STD_CELL_LIBRARY)__ebuf"
+set ::env(TRISTATE_CELLS) "$::env(STD_CELL_LIBRARY)__ebuf*"


### PR DESCRIPTION
Update deprecated variables to conform to latest LibreLane:

* `PLACE_SITE_WIDTH` and `PLACE_SITE_HEIGHT` have been deprecated since OpenLane 2.0.0b16. Now automatically extracted from PLACE_SITE.
* `FP_WELLTAP_CELL` and `FP_ENDCAP_CELL` have been deprecated since OpenLane 2.0.0b17. The new variables have the `FP_` prefix removed.
* `SYNTH_DRIVING_CELL_PIN` has been deprecated, instead use `SYNTH_DRIVING_CELL` with format `{cell}/{port}`.
* added `SYNTH_CLK_DRIVING_CELL` variable set to `clkinv`.
* `SYNTH_MIN_BUF_PORT` was deprecated, instead use `SYNTH_BUFFER_CELL` with format `{cell}/{input_port}/{output_port}`.
* `SYNTH_TIEHI_PORT`/`SYNTH_TIELO_PORT` are deprecated, instead use `SYNTH_TIEHI_CELL`/`SYNTH_TIELO_CELL` with format `{cell}/{port}`.
* `CELL_CLK_PORT` has been deprecated since OpenLane 2.0.0a24, it is not used in the current version.
* `FILL_CELL` and `DECAP_CELL` were renamed to `FILL_CELLS` and `DECAP_CELLS` since LibreLane 3.0.0.
* `RE_BUFFER_CELL` is not used in LibreLane.
* Instead of `DIODE_CELL_PIN`, use `DIODE_CELL` with format `{cell}/{port}`.
* `FAKEDIODE_CELL` is not used by LibreLane.
* `ROOT_CLK_BUFFER` not used in LibreLane (probably supposed to do what `CTS_ROOT_BUFFER` does).
* `CTS_CLK_BUFFER_LIST` was deprecated, use `CTS_CLK_BUFFERS` instead.
* `FP_PDN_RAIL_WIDTH` was deprecated, use `PDN_RAIL_WIDTH` instead.
* `CTS_MAX_CAP` is unnecessary, LibreLane will extract it from `CTS_CLK_BUFFERS`.
* `CTS_CLK_BUFFER_LIST` was deprecated, instead use `CTS_CLK_BUFFERS`.