### PR TITLE
Add support for postscript file generation

### DIFF
--- a/gf180mcu/magic/gf180mcu.tech
+++ b/gf180mcu/magic/gf180mcu.tech
@@ -5362,5 +5362,162 @@ plot
      draw nwell cwell
      draw pwell cwell
      draw dnwell cwell
+
+  style postscript
+    # --- Stipple Pattern Matrices (16*16 pixels) ---
+     1 30003000 00000000 03C003C0 00000000 03C003C0 00000000 00000000 00000000
+     2 F0F0F0F0 F0F0F0F0 00000000 00000000 0F0F0F0F 0F0F0F0F 00000000 00000000
+     3 FCFCFCFC 3F3F3F3F CFCFCFCF F3F3F3F3 FCFCFCFC 3F3F3F3F CFCFCFCF F3F3F3F3
+     4 00000000 00000000 F0F0F0F0 F0F0F0F0 00000000 00000000 F0F0F0F0 F0F0F0F0
+     5 30003000 0C000C00 03000300 00C000C0 00300030 000C000C 00030003 C000C000
+     6 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333
+     7 000C000C 00300030 00C000C0 03000300 0C000C00 30003000 C000C000 00030003
+     8 C003C003 000F000F 003C003C 00F000F0 03C003C0 0F000F00 3C003C00 F000F000
+     9 C003C003 F000F000 3C003C00 0F000F00 03C003C0 00F000F0 003C003C 000F000F
+    10 00000000 00000000 00000000 FFFFFFFF 00000000 00000000 00000000 FFFFFFFF
+    11 30303030 30303030 30303030 30303030 30303030 30303030 30303030 30303030
+    12 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC
+    13 0F0F0F0F 0F0F0F0F FFFFFFFF FFFFFFFF F0F0F0F0 F0F0F0F0 FFFFFFFF FFFFFFFF
+    14 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333
+    15 00000000 00030003 00000000 03C003C0 00000000 00000000 00000000 03C003C0
+    16 F000F000 003F003F FFFFFFFF FFFFFFFF F000F000 003F003F FFFFFFFF FFFFFFFF
+    17 F03FF03F F03FF03F F03FF03F F03FF03F F03FF03F F03FF03F F03FF03F F03FF03F
+    18 3FF03FF0 3FF03FF0 3FF03FF0 3FF03FF0 3FF03FF0 3FF03FF0 3FF03FF0 3FF03FF0
+    19 0FF00FF0 F00FF00F 300C300C 300C300C F00FF00F 0FF00FF0 0C300C30 0C300C30
+    20 0C300C30 300C300C C003C003 C003C003 300C300C 0C300C30 03C003C0 03C003C0
+    21 03000300 0C000C00 00000000 00000000 00000000 000C000C 00300030 00C000C0
+    22 00C000C0 00300030 00000000 00000000 00000000 30003000 0C000C00 03000300
+    23 0FF00FF0 3C3C3C3C F00FF00F C003C003 F00FF00F 3C3C3C3C 0FF00FF0 03C003C0
+    24 F00FF00F 0FF00FF0 CFF3CFF3 CFF3CFF3 0FF00FF0 F00FF00F F3CFF3CF F3CFF3CF
+    25 F3F3F3F3 CFCFCFCF 3F3F3F3F FCFCFCFC F3F3F3F3 CFCFCFCF 3F3F3F3F FCFCFCFC
+    26 FC0CFC0C 30FC30FC 330C330C 0CC30CC3 C330C330 FC30FC30 C0FCC0FC 03030303
+    27 3F033F03 303F303F 30033003 00000000 300C300C 3F0C3F0C 303F303F C3C3C3C3
+    28 C3C3C3C3 0FF00FF0 3FFC3FFC FC3FFC3F FC3FFC3F 3FFC3FFC 0FF00FF0 C3C3C3C3
+    29 30303030 C0C0C0C0 33333333 0C0C0C0C 30303030 C0C0C0C0 33333333 0C0C0C0C
+    30 0F000F00 3C003C00 F000F000 F003F003 3C0F3C0F 0F3C0F3C 03F003F0 03C003C0
+    31 33333333 F3CFF3CF 0C0C0C0C F3CFF3CF 33333333 F3CFF3CF 0C0C0C0C F3CFF3CF
+    32 3C003C00 F000F000 C003C003 000F000F 003C003C 00F000F0 03C003C0 0F000F00
+    33 00000000 00000000 00000000 0F000F00 3C003C00 3C003C00 0F000F00 00000000
+    34 00000000 000C000C 003C003C 00FC00FC 00FC00FC 003C003C 000C000C 00000000
+    35 00000000 3FFC3FFC 0FF00FF0 03C003C0 00000000 FC3FFC3F F00FF00F C003C003
+    36 FC00FC00 3C0C3C0C 0C3C0C3C 00FC00FC 00FC00FC 0C3C0C3C 3C0C3C0C FC00FC00
+
+    # --- Color Table (C M Y K) ---
+     1      0    0    0     55
+     2      0  145  145     35
+     3    176    0  176     42
+     4      0   53  110     53
+     5      0   57  103     86
+     6      0  154  140     71
+     7      0    0  255     25
+     8      0    0    0    255
+     9    127   86    0      5
+    10     41  191    0     64
+    11     37   79    0     33
+    12      0    0    0      0
+    13      0    0    0     85
+    14      0    0    0    110
+    15      0    0    0    255
+    16      0   54   44     16
+    17      0  122   82     16
+    18      0  255   67     45
+    19     60    0   48     39
+    20     89    0   57     64
+    21    255    0  255     74
+    22     76   42    0     13
+    23    255  255    0      5
+    24    195    0    5     86
+    25    191  121    0     76
+    26     42  255    0     55
+    27      0    7   76      0
+    28      0    0  255      0
+    29      0   40   81     20
+    30      0  111  175     21
+    31      0   59  255     57
+    32      0   57  255    116
+    33      0  136   53      0
+    34    199    0    3     27
+    35      0   83  193    135
+    36     33    0    0     25
+    37     36    0   36     45
+    38      0    0    0    255
+    39      0    0  248      9
+    40      0    0    0     75
+    41      0   55  200     25
+    42      0    0    0     20
+    43      0    0    0      0
+    44      0   75   75     45
+    45     90    0   90     49
+    46      0   39   56     54
+    47      0   26   47     71
+    48      0   74   68     63
+    49      0    0  136     40
+    50      0    0    0    125
+    51     70   48    0     30
+    52     21   94    0     59
+    53     89    0   38     45
+    54     55   70    0      0
+    55     53    0   18     42
+    56     22   22    0     25
+    57     19   42    0     44
+    58      0    0    0     70
+    59      0    0    0     95
+    60      0    0    0    155
+    61      0   66   45     35
+    62      0  116   23     35
+    63    138    0  138     80
+    64      0   87    0     80
+    65      0   53  148     40
+    66      0   76   30     27
+    67      0   30  107     40
+    68      0    0    0    255
+
+    # --- PDK Layer Style Remappings ---
+    magnet                                   8    5
+    padl                                     15   19
+    obsactive                                12   5
+    error_p,error_s,error_ps                 12   4
+    rpp,rpps,pdiffres,mvpdiffres             4    21
+    rnp,rpp,rnps,rpps,nhighres,mvnhighres    2    S
+    rnp,rnps,ndiffres,mvndiffres             3    22
+    glass,padl                               14   10
+    mimcap,mimcc                             13   12
+    mtphole                                  26   1
+    viatp,metaltp,rmtp,obsmtp,fillmtp        26   7
+    viatp,fence                              11   2
+    m5hole                                   24   1
+    via4,metal5,rm5,obsm5,fillm5,viatp,mimcap,mimcc 24   22
+    via4                                     15   5
+    m4hole                                   13   1
+    via3,metal4,rm4,obsm4,fillm4,via4        13   21
+    m3hole                                   33   1
+    m2hole                                   11   1
+    obsv2,m3c,metal3,rm3,obsm3,fillm3,via3   33   5
+    obsv2,m3c                                33   36
+    m1hole                                   9    1
+    obsv1,m2c,metal2,rm2,obsm2,fillm2,obsv2,m3c,padl 11   12
+    obsv1,m2c                                23   35
+    efuse,via3,rotate                        7    2
+    ppolyres,pdiode,pdiodec,mvpdiode,mvpdiodec,rm1,rm2,rm3,rm4,rm5,rmtp,rnp,rpp 4    7
+    npolyres,ppolyres,nhighres,mvnhighres    22   7
+    npolyres,ndiode,nndiode,ndiodec,nndiodec,mvndiode,mvnndiode,mvndiodec,mvnndiodec 3    5
+    ldpdiff,ldpdc                            32   25
+    ldndiff,ldndc                            21   3
+    mvpdiff,mvpsd,mvpfet,hvpfet,mvpvar,mvpdc,mvpsc,srammvpdiff,srammvpdc,mvpdiode,mvpdiodec,mvpdiffres 8    21
+    mvndiff,mvnsd,mvnfet,hvnfet,mvnnfet,mvnvar,mvndc,mvnsc,mvncap,srammvndiff,srammvndc,mvndiode,mvnndiode,mvndiodec,mvnndiodec,mvnhighres,mvndiffres 6    22
+    ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,ldndc,ldpdc,srammvndc,srammvpdc,sramndc,srampdc,pc,pdiodec,ndiodec,nndiodec,schottkyc,mvpdiodec,mvndiodec,mvnndiodec,metal1,rm1,obsm1,fillm1,obsv1,m2c 9    16
+    ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,ldndc,ldpdc,srammvndc,srammvpdc,sramndc,srampdc,pc,pdiodec,ndiodec,nndiodec,schottkyc,mvpdiodec,mvndiodec,mvnndiodec,mimcc 15   X
+    nvar,pvar,mvnvar,mvpvar,poly,pc,npolyres,ppolyres,efuse,fillpoly 2    14
+    pfet,pcap,mvpfet,hvpfet,mvpcap,srammvpfet,srampfet 6    14
+    nfet,nnfet,ncap,mvnfet,hvnfet,mvnnfet,mvncap,srammvnfet,sramnfet 5    14
+    psd,pvar,psc,mvpsd,mvpvar,mvpsc          4    13
+    nsd,nnfet,nvar,nsc,mvnsd,mvnnfet,mvnvar,mvnsc,nndiode,nndiodec,mvnndiode,mvnndiodec 3    13
+    pdiff,pdc,mvpdiff,mvpdc,srammvpdiff,srammvpdc,srampdiff,srampdc,pdiode,pdiodec,schottky,schottkyc,mvpdiode,mvpdiodec,pdiffres,mvpdiffres 4    14
+    ndiff,ndc,mvndiff,mvndc,srammvndiff,srammvndc,sramndiff,sramndc,ndiode,ndiodec,schottky,schottkyc,mvndiode,mvndiodec,ndiffres,mvndiffres,filldiff 3    14
+    pwell,pfet,pcap,pbase,pbase,mvpfet,hvpfet,mvpcap,srammvpfet,srampfet 4    5
+    rnwell,nfet,ncap,nbase,mvnfet,hvnfet,mvncap,srammvnfet,sramnfet 3    7
+    nwell,rnwell,nbase                       8    7
+    isosub                                   10   B
+    dnwell,fillblock,obswell                 7    7
 end
 

--- a/sky130/magic/sky130.tech
+++ b/sky130/magic/sky130.tech
@@ -6905,5 +6905,159 @@ plot
      draw m5fill no_color_at_all
      draw isosub no_color_at_all
      draw nwell cwell
+
+  style postscript
+
+    # --- Stipple Pattern Matrices (8 words x 32-bits) ---
+     1 30003000 00000000 03C003C0 00000000 03C003C0 00000000 00000000 00000000
+     2 F0F0F0F0 F0F0F0F0 00000000 00000000 0F0F0F0F 0F0F0F0F 00000000 00000000
+     3 FCFCFCFC 3F3F3F3F CFCFCFCF F3F3F3F3 FCFCFCFC 3F3F3F3F CFCFCFCF F3F3F3F3
+     4 00000000 00000000 F0F0F0F0 F0F0F0F0 00000000 00000000 F0F0F0F0 F0F0F0F0
+     5 30003000 0C000C00 03000300 00C000C0 00300030 000C000C 00030003 C000C000
+     6 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333
+     7 000C000C 00300030 00C000C0 03000300 0C000C00 30003000 C000C000 00030003
+     8 C003C003 000F000F 003C003C 00F000F0 03C003C0 0F000F00 3C003C00 F000F000
+     9 C003C003 F000F000 3C003C00 0F000F00 03C003C0 00F000F0 003C003C 000F000F
+    10 00000000 00000000 00000000 FFFFFFFF 00000000 00000000 00000000 FFFFFFFF
+    11 30303030 30303030 30303030 30303030 30303030 30303030 30303030 30303030
+    12 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC
+    13 0F0F0F0F 0F0F0F0F FFFFFFFF FFFFFFFF F0F0F0F0 F0F0F0F0 FFFFFFFF FFFFFFFF
+    14 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333 CCCCCCCC 33333333
+    15 00000000 00030003 00000000 03C003C0 00000000 00000000 00000000 03C003C0
+    16 F000F000 003F003F FFFFFFFF FFFFFFFF F000F000 003F003F FFFFFFFF FFFFFFFF
+    17 F03FF03F F03FF03F F03FF03F F03FF03F F03FF03F F03FF03F F03FF03F F03FF03F
+    18 3FF03FF0 3FF03FF0 3FF03FF0 3FF03FF0 3FF03FF0 3FF03FF0 3FF03FF0 3FF03FF0
+    19 0FF00FF0 F00FF00F 300C300C 300C300C F00FF00F 0FF00FF0 0C300C30 0C300C30
+    20 0C300C30 300C300C C003C003 C003C003 300C300C 0C300C30 03C003C0 03C003C0
+    21 03000300 0C000C00 00000000 00000000 00000000 000C000C 00300030 00C000C0
+    22 00C000C0 00300030 00000000 00000000 00000000 30003000 0C000C00 03000300
+    23 0FF00FF0 3C3C3C3C F00FF00F C003C003 F00FF00F 3C3C3C3C 0FF00FF0 03C003C0
+    24 F00FF00F 0FF00FF0 CFF3CFF3 CFF3CFF3 0FF00FF0 F00FF00F F3CFF3CF F3CFF3CF
+    25 F3F3F3F3 CFCFCFCF 3F3F3F3F FCFCFCFC F3F3F3F3 CFCFCFCF 3F3F3F3F FCFCFCFC
+    26 FC0CFC0C 30FC30FC 330C330C 0CC30CC3 C330C330 FC30FC30 C0FCC0FC 03030303
+    27 3F033F03 303F303F 30033003 00000000 300C300C 3F0C3F0C 303F303F C3C3C3C3
+    28 C3C3C3C3 0FF00FF0 3FFC3FFC FC3FFC3F FC3FFC3F 3FFC3FFC 0FF00FF0 C3C3C3C3
+    29 30303030 C0C0C0C0 33333333 0C0C0C0C 30303030 C0C0C0C0 33333333 0C0C0C0C
+    30 0F000F00 3C003C00 F000F000 F003F003 3C0F3C0F 0F3C0F3C 03F003F0 03C003C0
+    31 33333333 F3CFF3CF 0C0C0C0C F3CFF3CF 33333333 F3CFF3CF 0C0C0C0C F3CFF3CF
+    32 3C003C00 F000F000 C003C003 000F000F 003C003C 00F000F0 03C003C0 0F000F00
+    33 00000000 00000000 00000000 0F000F00 3C003C00 3C003C00 0F000F00 00000000
+    34 00000000 000C000C 003C003C 00FC00FC 00FC00FC 003C003C 000C000C 00000000
+    35 00000000 3FFC3FFC 0FF00FF0 03C003C0 00000000 FC3FFC3F F00FF00F C003C003
+    36 FC00FC00 3C0C3C0C 0C3C0C3C 00FC00FC 00FC00FC 0C3C0C3C 3C0C3C0C FC00FC00
+
+    # --- Color Table (C M Y K) ---
+     1      0  145  145     35
+     2    176    0  176     42
+     3      0   53  110     53
+     4      0   57  103     86
+     5      0  154  140     71
+     6      0    0  255     25
+     7      0    0    0    255
+     8    127   86    0      5
+     9     41  191    0     64
+    10     37   79    0     33
+    11      0    0    0      0
+    12      0    0    0     85
+    13      0    0    0    110
+    14      0    0    0    255
+    15      0   54   44     16
+    16      0  122   82     16
+    17      0  255   67     45
+    18     60    0   48     39
+    19     89    0   57     64
+    20    255    0  255     74
+    21     76   42    0     13
+    22    255  255    0      5
+    23    195    0    5     86
+    24    191  121    0     76
+    25     42  255    0     55
+    26      0    7   76      0
+    27      0    0  255      0
+    28      0   40   81     20
+    29      0  111  175     21
+    30      0   59  255     57
+    31      0   57  255    116
+    32      0  136   53      0
+    33    199    0    3     27
+    34      0   83  193    135
+    35     33    0    0     25
+    36     36    0   36     45
+    37      0    0    0    255
+    38      0    0  248      9
+    39      0    0    0     75
+    40      0   55  200     25
+    41      0    0    0     20
+    42      0    0    0      0
+    43      0   75   75     45
+    44     90    0   90     49
+    45      0   39   56     54
+    46      0   26   47     71
+    47      0   74   68     63
+    48      0    0  136     40
+    49      0    0    0    125
+    50     70   48    0     30
+    51     21   94    0     59
+    52     89    0   38     45
+    53     55   70    0      0
+    54     53    0   18     42
+    55     22   22    0     25
+    56     19   42    0     44
+    57      0    0    0     70
+    58      0    0    0     95
+    59      0    0    0    155
+    60      0   66   45     35
+    61      0  116   23     35
+    62    138    0  138     80
+    63      0   87    0     80
+    64      0   53  148     40
+    65      0   76   30     27
+    66      0   30  107     40
+
+    # --- PDK Layer Style Remappings ---
+    magnet                                   7    5
+    obsactive                                11   5
+    error_p,error_s,error_ps                 11   4
+    pdiffres,mvpdiffres                      3    21
+    ndiffres,mvndiffres                      2    22
+    mrp1,xhrpoly,uhrpoly                     1    5
+    pi2                                      30   29
+    ubm,pi2,glass                            13   10
+    mrdlc                                    25   28
+    via4,metal5,m5fill,rm5,obsm5,mrdlc       25   7
+    via4,fence                               10   2
+    via3,metal4,m4fill,rm4,obsm4,via4        23   22
+    via3                                     14   5
+    mimcap,mimcc,mimcap2,mim2cc              12   12
+    m3c,metal3,m3fill,rm3,obsm3,mimcap2,mim2cc,via3 12   21
+    m3c,rotate                               6    2
+    m2c,metal2,m2fill,rm2,obsm2,m3c,mimcap,mimcc 32   5
+    m2c                                      32   36
+    mcon,obsmcon,metal1,m1fill,rm1,obsm1,m2c 10   12
+    mcon,obsmcon                             22   35
+    ppolyres,xpc,rmp,pdiode,pdiodec,pdiodelvt,pdiodehvt,pdilvtc,pdihvtc,mvpdiode,mvpdiodec,rli,rm1,rm2,rm3,rm4,rm5,mrp1 3    7
+    npolyres,ppolyres,xhrpoly                21   7
+    npolyres,ndiode,ndiodec,nndiode,ndiodelvt,ndilvtc,mvndiode,mvndiodec,nndiodec 2    5
+    extdrain                                 2    15
+    extdrain                                 3    1
+    mvpdiff,mvpsd,mvpdc,mvpsc,mvpdiode,mvpdiodec,mvpdiffres 7    21
+    mvndiff,mvnsd,mvnfet,mvnfetesd,mvnnfet,mvvar,mvndc,mvnsc,mvndiode,mvndiodec,nndiodec,mvndiffres 5    22
+    pfetmvt,nsonos,nndiode,mrdlc,metalrdl,obsmrdl,pi2 17   5
+    ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,pc,xpc,pdiodec,ndiodec,pdilvtc,pdihvtc,ndilvtc,mvpdiodec,mvndiodec,nndiodec,locali,lifill,coreli,rli,mcon,obsli,obsmcon 8    16
+    ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,pc,xpc,pdiodec,ndiodec,pdilvtc,pdihvtc,ndilvtc,mvpdiodec,mvndiodec,nndiodec,mimcc,mim2cc 14   0
+    var,corenvar,corepvar,varhvt,mvvar,poly,polyfill,pc,npolyres,ppolyres,xpc,rmp 1    14
+    scpfethvt,pfethvt,varhvt,pdiodehvt,pdihvtc 27   5
+    pfet,scpfet,scpfethvt,ppu,pfetlvt,pfetmvt,pfethvt,mvpfet,mvpfetesd 5    14
+    scnfetlvt,pfetlvt,nfetlvt,ndiodelvt,pdiodelvt,pdilvtc,ndilvtc 30   5
+    nfet,scnfet,scnfetlvt,npass,npd,nfetlvt,nsonos,nnfet,mvnfet,mvnfetesd,mvnnfet 4    14
+    nfet,scnfet,scnfetlvt,npass,npd,pnp,nfetlvt,mvnfet,mvnfetesd 2    7
+    psd,psc,corepvar,mvpsd,mvpsc             3    13
+    nsd,var,nsc,corenvar,varhvt,nnfet,mvnsd,mvnnfet,mvvar,mvnsc,nndiodec 2    13
+    pdiff,pdc,mvpdiff,mvpdc,pdiode,pdiodec,pdiodelvt,pdiodehvt,pdilvtc,pdihvtc,mvpdiode,mvpdiodec,pdiffres,mvpdiffres 3    14
+    ndiff,fomfill,ndc,mvndiff,mvndc,ndiode,ndiodec,nndiode,ndiodelvt,ndilvtc,mvndiode,mvndiodec,ndiffres,mvndiffres 2    14
+    pwell,rpwell,rpwell,pfet,scpfet,scpfethvt,ppu,npn,npn,pfetlvt,pfetmvt,pfethvt,mvpfet,mvpfetesd 3    5
+    nwell,photo,photo,pnp                    7    7
+    isosub                                   9    0
+    dnwell,fillblock,obswell                 6    7
 end
 

--- a/sky130/magic/sky130.tech
+++ b/sky130/magic/sky130.tech
@@ -6907,7 +6907,6 @@ plot
      draw nwell cwell
 
   style postscript
-
     # --- Stipple Pattern Matrices (8 words x 32-bits) ---
      1 30003000 00000000 03C003C0 00000000 03C003C0 00000000 00000000 00000000
      2 F0F0F0F0 F0F0F0F0 00000000 00000000 0F0F0F0F 0F0F0F0F 00000000 00000000
@@ -6947,117 +6946,119 @@ plot
     36 FC00FC00 3C0C3C0C 0C3C0C3C 00FC00FC 00FC00FC 0C3C0C3C 3C0C3C0C FC00FC00
 
     # --- Color Table (C M Y K) ---
-     1      0  145  145     35
-     2    176    0  176     42
-     3      0   53  110     53
-     4      0   57  103     86
-     5      0  154  140     71
-     6      0    0  255     25
-     7      0    0    0    255
-     8    127   86    0      5
-     9     41  191    0     64
-    10     37   79    0     33
-    11      0    0    0      0
-    12      0    0    0     85
-    13      0    0    0    110
-    14      0    0    0    255
-    15      0   54   44     16
-    16      0  122   82     16
-    17      0  255   67     45
-    18     60    0   48     39
-    19     89    0   57     64
-    20    255    0  255     74
-    21     76   42    0     13
-    22    255  255    0      5
-    23    195    0    5     86
-    24    191  121    0     76
-    25     42  255    0     55
-    26      0    7   76      0
-    27      0    0  255      0
-    28      0   40   81     20
-    29      0  111  175     21
-    30      0   59  255     57
-    31      0   57  255    116
-    32      0  136   53      0
-    33    199    0    3     27
-    34      0   83  193    135
-    35     33    0    0     25
-    36     36    0   36     45
-    37      0    0    0    255
-    38      0    0  248      9
-    39      0    0    0     75
-    40      0   55  200     25
-    41      0    0    0     20
-    42      0    0    0      0
-    43      0   75   75     45
-    44     90    0   90     49
-    45      0   39   56     54
-    46      0   26   47     71
-    47      0   74   68     63
-    48      0    0  136     40
-    49      0    0    0    125
-    50     70   48    0     30
-    51     21   94    0     59
-    52     89    0   38     45
-    53     55   70    0      0
-    54     53    0   18     42
-    55     22   22    0     25
-    56     19   42    0     44
-    57      0    0    0     70
-    58      0    0    0     95
-    59      0    0    0    155
-    60      0   66   45     35
-    61      0  116   23     35
-    62    138    0  138     80
-    63      0   87    0     80
-    64      0   53  148     40
-    65      0   76   30     27
-    66      0   30  107     40
+     1      0    0    0     55
+     2      0  145  145     35
+     3    176    0  176     42
+     4      0   53  110     53
+     5      0   57  103     86
+     6      0  154  140     71
+     7      0    0  255     25
+     8      0    0    0    255
+     9    127   86    0      5
+    10     41  191    0     64
+    11     37   79    0     33
+    12      0    0    0      0
+    13      0    0    0     85
+    14      0    0    0    110
+    15      0    0    0    255
+    16      0   54   44     16
+    17      0  122   82     16
+    18      0  255   67     45
+    19     60    0   48     39
+    20     89    0   57     64
+    21    255    0  255     74
+    22     76   42    0     13
+    23    255  255    0      5
+    24    195    0    5     86
+    25    191  121    0     76
+    26     42  255    0     55
+    27      0    7   76      0
+    28      0    0  255      0
+    29      0   40   81     20
+    30      0  111  175     21
+    31      0   59  255     57
+    32      0   57  255    116
+    33      0  136   53      0
+    34    199    0    3     27
+    35      0   83  193    135
+    36     33    0    0     25
+    37     36    0   36     45
+    38      0    0    0    255
+    39      0    0  248      9
+    40      0    0    0     75
+    41      0   55  200     25
+    42      0    0    0     20
+    43      0    0    0      0
+    44      0   75   75     45
+    45     90    0   90     49
+    46      0   39   56     54
+    47      0   26   47     71
+    48      0   74   68     63
+    49      0    0  136     40
+    50      0    0    0    125
+    51     70   48    0     30
+    52     21   94    0     59
+    53     89    0   38     45
+    54     55   70    0      0
+    55     53    0   18     42
+    56     22   22    0     25
+    57     19   42    0     44
+    58      0    0    0     70
+    59      0    0    0     95
+    60      0    0    0    155
+    61      0   66   45     35
+    62      0  116   23     35
+    63    138    0  138     80
+    64      0   87    0     80
+    65      0   53  148     40
+    66      0   76   30     27
+    67      0   30  107     40
+    68      0    0    0    255
 
     # --- PDK Layer Style Remappings ---
-    magnet                                   7    5
-    obsactive                                11   5
-    error_p,error_s,error_ps                 11   4
-    pdiffres,mvpdiffres                      3    21
-    ndiffres,mvndiffres                      2    22
-    mrp1,xhrpoly,uhrpoly                     1    5
-    pi2                                      30   29
-    ubm,pi2,glass                            13   10
-    mrdlc                                    25   28
-    via4,metal5,m5fill,rm5,obsm5,mrdlc       25   7
-    via4,fence                               10   2
-    via3,metal4,m4fill,rm4,obsm4,via4        23   22
-    via3                                     14   5
-    mimcap,mimcc,mimcap2,mim2cc              12   12
-    m3c,metal3,m3fill,rm3,obsm3,mimcap2,mim2cc,via3 12   21
-    m3c,rotate                               6    2
-    m2c,metal2,m2fill,rm2,obsm2,m3c,mimcap,mimcc 32   5
-    m2c                                      32   36
-    mcon,obsmcon,metal1,m1fill,rm1,obsm1,m2c 10   12
-    mcon,obsmcon                             22   35
-    ppolyres,xpc,rmp,pdiode,pdiodec,pdiodelvt,pdiodehvt,pdilvtc,pdihvtc,mvpdiode,mvpdiodec,rli,rm1,rm2,rm3,rm4,rm5,mrp1 3    7
-    npolyres,ppolyres,xhrpoly                21   7
-    npolyres,ndiode,ndiodec,nndiode,ndiodelvt,ndilvtc,mvndiode,mvndiodec,nndiodec 2    5
-    extdrain                                 2    15
-    extdrain                                 3    1
-    mvpdiff,mvpsd,mvpdc,mvpsc,mvpdiode,mvpdiodec,mvpdiffres 7    21
-    mvndiff,mvnsd,mvnfet,mvnfetesd,mvnnfet,mvvar,mvndc,mvnsc,mvndiode,mvndiodec,nndiodec,mvndiffres 5    22
-    pfetmvt,nsonos,nndiode,mrdlc,metalrdl,obsmrdl,pi2 17   5
-    ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,pc,xpc,pdiodec,ndiodec,pdilvtc,pdihvtc,ndilvtc,mvpdiodec,mvndiodec,nndiodec,locali,lifill,coreli,rli,mcon,obsli,obsmcon 8    16
-    ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,pc,xpc,pdiodec,ndiodec,pdilvtc,pdihvtc,ndilvtc,mvpdiodec,mvndiodec,nndiodec,mimcc,mim2cc 14   0
-    var,corenvar,corepvar,varhvt,mvvar,poly,polyfill,pc,npolyres,ppolyres,xpc,rmp 1    14
-    scpfethvt,pfethvt,varhvt,pdiodehvt,pdihvtc 27   5
-    pfet,scpfet,scpfethvt,ppu,pfetlvt,pfetmvt,pfethvt,mvpfet,mvpfetesd 5    14
-    scnfetlvt,pfetlvt,nfetlvt,ndiodelvt,pdiodelvt,pdilvtc,ndilvtc 30   5
-    nfet,scnfet,scnfetlvt,npass,npd,nfetlvt,nsonos,nnfet,mvnfet,mvnfetesd,mvnnfet 4    14
-    nfet,scnfet,scnfetlvt,npass,npd,pnp,nfetlvt,mvnfet,mvnfetesd 2    7
-    psd,psc,corepvar,mvpsd,mvpsc             3    13
-    nsd,var,nsc,corenvar,varhvt,nnfet,mvnsd,mvnnfet,mvvar,mvnsc,nndiodec 2    13
-    pdiff,pdc,mvpdiff,mvpdc,pdiode,pdiodec,pdiodelvt,pdiodehvt,pdilvtc,pdihvtc,mvpdiode,mvpdiodec,pdiffres,mvpdiffres 3    14
-    ndiff,fomfill,ndc,mvndiff,mvndc,ndiode,ndiodec,nndiode,ndiodelvt,ndilvtc,mvndiode,mvndiodec,ndiffres,mvndiffres 2    14
-    pwell,rpwell,rpwell,pfet,scpfet,scpfethvt,ppu,npn,npn,pfetlvt,pfetmvt,pfethvt,mvpfet,mvpfetesd 3    5
-    nwell,photo,photo,pnp                    7    7
-    isosub                                   9    0
-    dnwell,fillblock,obswell                 6    7
+    magnet                                   8    5
+    obsactive                                12   5
+    error_p,error_s,error_ps                 12   4
+    pdiffres,mvpdiffres                      4    21
+    ndiffres,mvndiffres                      3    22
+    mrp1,xhrpoly,uhrpoly                     2    S
+    pi2                                      31   29
+    ubm,pi2,glass                            14   10
+    mrdlc                                    26   28
+    via4,metal5,m5fill,rm5,obsm5,mrdlc       26   7
+    via4,fence                               11   2
+    via3,metal4,m4fill,rm4,obsm4,via4        24   22
+    via3                                     15   5
+    mimcap,mimcc,mimcap2,mim2cc              13   12
+    m3c,metal3,m3fill,rm3,obsm3,mimcap2,mim2cc,via3 13   21
+    m3c,rotate                               7    2
+    m2c,metal2,m2fill,rm2,obsm2,m3c,mimcap,mimcc 33   5
+    m2c                                      33   36
+    mcon,obsmcon,metal1,m1fill,rm1,obsm1,m2c 11   12
+    mcon,obsmcon                             23   35
+    ppolyres,xpc,rmp,pdiode,pdiodec,pdiodelvt,pdiodehvt,pdilvtc,pdihvtc,mvpdiode,mvpdiodec,rli,rm1,rm2,rm3,rm4,rm5,mrp1 4    7
+    npolyres,ppolyres,xhrpoly                22   7
+    npolyres,ndiode,ndiodec,nndiode,ndiodelvt,ndilvtc,mvndiode,mvndiodec,nndiodec 3    5
+    extdrain                                 3    15
+    extdrain                                 4    1
+    mvpdiff,mvpsd,mvpdc,mvpsc,mvpdiode,mvpdiodec,mvpdiffres 8    21
+    mvndiff,mvnsd,mvnfet,mvnfetesd,mvnnfet,mvvar,mvndc,mvnsc,mvndiode,mvndiodec,nndiodec,mvndiffres 6    22
+    pfetmvt,nsonos,nndiode,mrdlc,metalrdl,obsmrdl,pi2 18   5
+    ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,pc,xpc,pdiodec,ndiodec,pdilvtc,pdihvtc,ndilvtc,mvpdiodec,mvndiodec,nndiodec,locali,lifill,coreli,rli,mcon,obsli,obsmcon 9    16
+    ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,pc,xpc,pdiodec,ndiodec,pdilvtc,pdihvtc,ndilvtc,mvpdiodec,mvndiodec,nndiodec,mimcc,mim2cc 15   X
+    var,corenvar,corepvar,varhvt,mvvar,poly,polyfill,pc,npolyres,ppolyres,xpc,rmp 2    14
+    scpfethvt,pfethvt,varhvt,pdiodehvt,pdihvtc 28   5
+    pfet,scpfet,scpfethvt,ppu,pfetlvt,pfetmvt,pfethvt,mvpfet,mvpfetesd 6    14
+    scnfetlvt,pfetlvt,nfetlvt,ndiodelvt,pdiodelvt,pdilvtc,ndilvtc 31   5
+    nfet,scnfet,scnfetlvt,npass,npd,nfetlvt,nsonos,nnfet,mvnfet,mvnfetesd,mvnnfet 5    14
+    nfet,scnfet,scnfetlvt,npass,npd,pnp,nfetlvt,mvnfet,mvnfetesd 3    7
+    psd,psc,corepvar,mvpsd,mvpsc             4    13
+    nsd,var,nsc,corenvar,varhvt,nnfet,mvnsd,mvnnfet,mvvar,mvnsc,nndiodec 3    13
+    pdiff,pdc,mvpdiff,mvpdc,pdiode,pdiodec,pdiodelvt,pdiodehvt,pdilvtc,pdihvtc,mvpdiode,mvpdiodec,pdiffres,mvpdiffres 4    14
+    ndiff,fomfill,ndc,mvndiff,mvndc,ndiode,ndiodec,nndiode,ndiodelvt,ndilvtc,mvndiode,mvndiodec,ndiffres,mvndiffres 3    14
+    pwell,rpwell,rpwell,pfet,scpfet,scpfethvt,ppu,npn,npn,pfetlvt,pfetmvt,pfethvt,mvpfet,mvpfetesd 4    5
+    nwell,photo,photo,pnp                    8    7
+    isosub                                   10   B
+    dnwell,fillblock,obswell                 7    7
 end
 

--- a/sky130/magic/sky130.tech
+++ b/sky130/magic/sky130.tech
@@ -6907,7 +6907,7 @@ plot
      draw nwell cwell
 
   style postscript
-    # --- Stipple Pattern Matrices (8 words x 32-bits) ---
+    # --- Stipple Pattern Matrices (16*16 pixels) ---
      1 30003000 00000000 03C003C0 00000000 03C003C0 00000000 00000000 00000000
      2 F0F0F0F0 F0F0F0F0 00000000 00000000 0F0F0F0F 0F0F0F0F 00000000 00000000
      3 FCFCFCFC 3F3F3F3F CFCFCFCF F3F3F3F3 FCFCFCFC 3F3F3F3F CFCFCFCF F3F3F3F3
@@ -7032,9 +7032,10 @@ plot
     mimcap,mimcc,mimcap2,mim2cc              13   12
     m3c,metal3,m3fill,rm3,obsm3,mimcap2,mim2cc,via3 13   21
     m3c,rotate                               7    2
-    m2c,metal2,m2fill,rm2,obsm2,m3c,mimcap,mimcc 33   5
+    reram                                    15   19
+    m2c,reram,metal2,m2fill,rm2,obsm2,m3c,mimcap,mimcc 33   5
     m2c                                      33   36
-    mcon,obsmcon,metal1,m1fill,rm1,obsm1,m2c 11   12
+    mcon,obsmcon,metal1,m1fill,rm1,obsm1,m2c,reram 11   12
     mcon,obsmcon                             23   35
     ppolyres,xpc,rmp,pdiode,pdiodec,pdiodelvt,pdiodehvt,pdilvtc,pdihvtc,mvpdiode,mvpdiodec,rli,rm1,rm2,rm3,rm4,rm5,mrp1 4    7
     npolyres,ppolyres,xhrpoly                22   7
@@ -7045,7 +7046,7 @@ plot
     mvndiff,mvnsd,mvnfet,mvnfetesd,mvnnfet,mvvar,mvndc,mvnsc,mvndiode,mvndiodec,nndiodec,mvndiffres 6    22
     pfetmvt,nsonos,nndiode,mrdlc,metalrdl,obsmrdl,pi2 18   5
     ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,pc,xpc,pdiodec,ndiodec,pdilvtc,pdihvtc,ndilvtc,mvpdiodec,mvndiodec,nndiodec,locali,lifill,coreli,rli,mcon,obsli,obsmcon 9    16
-    ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,pc,xpc,pdiodec,ndiodec,pdilvtc,pdihvtc,ndilvtc,mvpdiodec,mvndiodec,nndiodec,mimcc,mim2cc 15   X
+    ndc,pdc,nsc,psc,mvndc,mvpdc,mvnsc,mvpsc,pc,xpc,pdiodec,ndiodec,pdilvtc,pdihvtc,ndilvtc,mvpdiodec,mvndiodec,nndiodec,reram,mimcc,mim2cc 15   X
     var,corenvar,corepvar,varhvt,mvvar,poly,polyfill,pc,npolyres,ppolyres,xpc,rmp 2    14
     scpfethvt,pfethvt,varhvt,pdiodehvt,pdihvtc 28   5
     pfet,scpfet,scpfethvt,ppu,pfetlvt,pfetmvt,pfethvt,mvpfet,mvpfetesd 6    14


### PR DESCRIPTION
Added support for postscript file generation be including a section based on 
http://opencircuitdesign.com/magic/tech.html
http://opencircuitdesign.com/magic/archive/scmos-sub.tech

Layers were automatically generated from the mos.24bit.dstyle and mos.24bit.std.cmap files along with the styles section in the current tech file. stipples and colors as well as layer order were preserved as best as possible.