### PR TITLE
sky130: added latches with reset

### DIFF
--- a/sky130/librelane/sky130_fd_sc_hd/latch_map.v
+++ b/sky130/librelane/sky130_fd_sc_hd/latch_map.v
@@ -1,21 +1,74 @@
+// Delay latch, non-inverted enable, single output
 module \$_DLATCH_P_ (input E, input D, output Q);
   sky130_fd_sc_hd__dlxtp_1 _TECHMAP_DLATCH_P (
-    //# {{data|Data Signals}}
-    .D(D),
-    .Q(Q),
-
-    //# {{clocks|Clocking}}
-    .GATE(E)
+    .Q    (Q),
+    .D    (D),
+    .GATE (E)
   );
 endmodule
 
+// Delay latch, inverted enable, single output
 module \$_DLATCH_N_ (input E, input D, output Q);
   sky130_fd_sc_hd__dlxtn_1 _TECHMAP_DLATCH_N (
-    //# {{data|Data Signals}}
-    .D(D),
-    .Q(Q),
-
-    //# {{clocks|Clocking}}
-    .GATE_N(E)
+    .Q      (Q),
+    .D      (D),
+    .GATE_N (E)
   );
 endmodule
+
+// Delay latch, inverted reset, non-inverted enable, single output
+module \$_DLATCH_PN0_ (input E, input R, input D, output Q);
+  sky130_fd_sc_hd__dlrtp_1 _TECHMAP_DLATCH_PN0 (
+    .Q       (Q),
+    .RESET_B (R),
+    .D       (D),
+    .GATE    (E)
+  );
+endmodule
+
+// Delay latch, inverted reset, inverted enable, single output
+module \$_DLATCH_NN0_ (input E, input R, input D, output Q);
+  sky130_fd_sc_hd__dlrtn_1 _TECHMAP_DLATCH_NN0 (
+    .Q       (Q),
+    .RESET_B (R),
+    .D       (D),
+    .GATE_N  (E)
+  );
+endmodule
+
+// while the SCL also contains the following lathes with complementary outputs,
+// they are commented out, since Yosys lacks primities mapping for complementary outputs
+
+// Delay latch, non-inverted enable, complementary outputs
+//module sky130_fd_sc_hd__dlxbp_1 (
+//    Q   ,
+//    Q_N ,
+//    D   ,
+//    GATE
+//);
+
+// Delay latch, inverted enable, complementary outputs
+//module sky130_fd_sc_hd__dlxbn_1 (
+//    Q     ,
+//    Q_N   ,
+//    D     ,
+//    GATE_N
+//);
+
+// Delay latch, inverted reset, non-inverted enable, complementary outputs
+//module sky130_fd_sc_hd__dlrbp_1 (
+//    Q      ,
+//    Q_N    ,
+//    RESET_B,
+//    D      ,
+//    GATE
+//);
+
+// Delay latch, inverted reset, inverted enable, complementary outputs
+//module sky130_fd_sc_hd__dlrbn_1 (
+//    Q      ,
+//    Q_N    ,
+//    RESET_B,
+//    D      ,
+//    GATE_N
+//);

--- a/sky130/librelane/sky130_fd_sc_hdll/latch_map.v
+++ b/sky130/librelane/sky130_fd_sc_hdll/latch_map.v
@@ -1,21 +1,28 @@
-module \$_DLATCH_P_ (input E, input D, output Q);
-  sky130_fd_sc_hdll__dlxtp_1 _TECHMAP_DLATCH_P (
-    //# {{data|Data Signals}}
-    .D(D),
-    .Q(Q),
-
-    //# {{clocks|Clocking}}
-    .GATE(E)
+// Delay latch, inverted enable, single output
+module \$_DLATCH_N_ (input E, input D, output Q);
+  sky130_fd_sc_hd__dlxtn_1 _TECHMAP_DLATCH_N (
+    .Q      (Q),
+    .D      (D),
+    .GATE_N (E)
   );
 endmodule
 
-module \$_DLATCH_N_ (input E, input D, output Q);
-  sky130_fd_sc_hdll__dlxtn_1 _TECHMAP_DLATCH_N (
-    //# {{data|Data Signals}}
-    .D(D),
-    .Q(Q),
+// Delay latch, inverted reset, non-inverted enable, single output
+module \$_DLATCH_PN0_ (input E, input R, input D, output Q);
+  sky130_fd_sc_hd__dlrtp_1 _TECHMAP_DLATCH_PN0 (
+    .Q       (Q),
+    .RESET_B (R),
+    .D       (D),
+    .GATE    (E)
+  );
+endmodule
 
-    //# {{clocks|Clocking}}
-    .GATE_N(E)
+// Delay latch, inverted reset, inverted enable, single output
+module \$_DLATCH_NN0_ (input E, input R, input D, output Q);
+  sky130_fd_sc_hd__dlrtn_1 _TECHMAP_DLATCH_NN0 (
+    .Q       (Q),
+    .RESET_B (R),
+    .D       (D),
+    .GATE_N  (E)
   );
 endmodule

--- a/sky130/librelane/sky130_fd_sc_hs/latch_map.v
+++ b/sky130/librelane/sky130_fd_sc_hs/latch_map.v
@@ -1,21 +1,74 @@
+// Delay latch, non-inverted enable, single output
 module \$_DLATCH_P_ (input E, input D, output Q);
   sky130_fd_sc_hs__dlxtp_1 _TECHMAP_DLATCH_P (
-    //# {{data|Data Signals}}
-    .D(D),
-    .Q(Q),
-
-    //# {{clocks|Clocking}}
-    .GATE(E)
+    .Q    (Q),
+    .D    (D),
+    .GATE (E)
   );
 endmodule
 
+// Delay latch, inverted enable, single output
 module \$_DLATCH_N_ (input E, input D, output Q);
   sky130_fd_sc_hs__dlxtn_1 _TECHMAP_DLATCH_N (
-    //# {{data|Data Signals}}
-    .D(D),
-    .Q(Q),
-
-    //# {{clocks|Clocking}}
-    .GATE_N(E)
+    .Q      (Q),
+    .D      (D),
+    .GATE_N (E)
   );
 endmodule
+
+// Delay latch, inverted reset, non-inverted enable, single output
+module \$_DLATCH_PN0_ (input E, input R, input D, output Q);
+  sky130_fd_sc_hs__dlrtp_1 _TECHMAP_DLATCH_PN0 (
+    .Q       (Q),
+    .RESET_B (R),
+    .D       (D),
+    .GATE    (E)
+  );
+endmodule
+
+// Delay latch, inverted reset, inverted enable, single output
+module \$_DLATCH_NN0_ (input E, input R, input D, output Q);
+  sky130_fd_sc_hs__dlrtn_1 _TECHMAP_DLATCH_NN0 (
+    .Q       (Q),
+    .RESET_B (R),
+    .D       (D),
+    .GATE_N  (E)
+  );
+endmodule
+
+// while the SCL also contains the following lathes with complementary outputs,
+// they are commented out, since Yosys lacks primities mapping for complementary outputs
+
+// Delay latch, non-inverted enable, complementary outputs
+//module sky130_fd_sc_hs__dlxbp_1 (
+//    Q   ,
+//    Q_N ,
+//    D   ,
+//    GATE
+//);
+
+// Delay latch, inverted enable, complementary outputs
+//module sky130_fd_sc_hs__dlxbn_1 (
+//    Q     ,
+//    Q_N   ,
+//    D     ,
+//    GATE_N
+//);
+
+// Delay latch, inverted reset, non-inverted enable, complementary outputs
+//module sky130_fd_sc_hs__dlrbp_1 (
+//    Q      ,
+//    Q_N    ,
+//    RESET_B,
+//    D      ,
+//    GATE
+//);
+
+// Delay latch, inverted reset, inverted enable, complementary outputs
+//module sky130_fd_sc_hs__dlrbn_1 (
+//    Q      ,
+//    Q_N    ,
+//    RESET_B,
+//    D      ,
+//    GATE_N
+//);

--- a/sky130/librelane/sky130_fd_sc_ls/latch_map.v
+++ b/sky130/librelane/sky130_fd_sc_ls/latch_map.v
@@ -1,21 +1,74 @@
+// Delay latch, non-inverted enable, single output
 module \$_DLATCH_P_ (input E, input D, output Q);
   sky130_fd_sc_ls__dlxtp_1 _TECHMAP_DLATCH_P (
-    //# {{data|Data Signals}}
-    .D(D),
-    .Q(Q),
-
-    //# {{clocks|Clocking}}
-    .GATE(E)
+    .Q    (Q),
+    .D    (D),
+    .GATE (E)
   );
 endmodule
 
+// Delay latch, inverted enable, single output
 module \$_DLATCH_N_ (input E, input D, output Q);
   sky130_fd_sc_ls__dlxtn_1 _TECHMAP_DLATCH_N (
-    //# {{data|Data Signals}}
-    .D(D),
-    .Q(Q),
-
-    //# {{clocks|Clocking}}
-    .GATE_N(E)
+    .Q      (Q),
+    .D      (D),
+    .GATE_N (E)
   );
 endmodule
+
+// Delay latch, inverted reset, non-inverted enable, single output
+module \$_DLATCH_PN0_ (input E, input R, input D, output Q);
+  sky130_fd_sc_ls__dlrtp_1 _TECHMAP_DLATCH_PN0 (
+    .Q       (Q),
+    .RESET_B (R),
+    .D       (D),
+    .GATE    (E)
+  );
+endmodule
+
+// Delay latch, inverted reset, inverted enable, single output
+module \$_DLATCH_NN0_ (input E, input R, input D, output Q);
+  sky130_fd_sc_ls__dlrtn_1 _TECHMAP_DLATCH_NN0 (
+    .Q       (Q),
+    .RESET_B (R),
+    .D       (D),
+    .GATE_N  (E)
+  );
+endmodule
+
+// while the SCL also contains the following lathes with complementary outputs,
+// they are commented out, since Yosys lacks primities mapping for complementary outputs
+
+// Delay latch, non-inverted enable, complementary outputs
+//module sky130_fd_sc_ls__dlxbp_1 (
+//    Q   ,
+//    Q_N ,
+//    D   ,
+//    GATE
+//);
+
+// Delay latch, inverted enable, complementary outputs
+//module sky130_fd_sc_ls__dlxbn_1 (
+//    Q     ,
+//    Q_N   ,
+//    D     ,
+//    GATE_N
+//);
+
+// Delay latch, inverted reset, non-inverted enable, complementary outputs
+//module sky130_fd_sc_ls__dlrbp_1 (
+//    Q      ,
+//    Q_N    ,
+//    RESET_B,
+//    D      ,
+//    GATE
+//);
+
+// Delay latch, inverted reset, inverted enable, complementary outputs
+//module sky130_fd_sc_ls__dlrbn_1 (
+//    Q      ,
+//    Q_N    ,
+//    RESET_B,
+//    D      ,
+//    GATE_N
+//);

--- a/sky130/librelane/sky130_fd_sc_ms/latch_map.v
+++ b/sky130/librelane/sky130_fd_sc_ms/latch_map.v
@@ -1,21 +1,74 @@
+// Delay latch, non-inverted enable, single output
 module \$_DLATCH_P_ (input E, input D, output Q);
   sky130_fd_sc_ms__dlxtp_1 _TECHMAP_DLATCH_P (
-    //# {{data|Data Signals}}
-    .D(D),
-    .Q(Q),
-
-    //# {{clocks|Clocking}}
-    .GATE(E)
+    .Q    (Q),
+    .D    (D),
+    .GATE (E)
   );
 endmodule
 
+// Delay latch, inverted enable, single output
 module \$_DLATCH_N_ (input E, input D, output Q);
   sky130_fd_sc_ms__dlxtn_1 _TECHMAP_DLATCH_N (
-    //# {{data|Data Signals}}
-    .D(D),
-    .Q(Q),
-
-    //# {{clocks|Clocking}}
-    .GATE_N(E)
+    .Q      (Q),
+    .D      (D),
+    .GATE_N (E)
   );
 endmodule
+
+// Delay latch, inverted reset, non-inverted enable, single output
+module \$_DLATCH_PN0_ (input E, input R, input D, output Q);
+  sky130_fd_sc_ms__dlrtp_1 _TECHMAP_DLATCH_PN0 (
+    .Q       (Q),
+    .RESET_B (R),
+    .D       (D),
+    .GATE    (E)
+  );
+endmodule
+
+// Delay latch, inverted reset, inverted enable, single output
+module \$_DLATCH_NN0_ (input E, input R, input D, output Q);
+  sky130_fd_sc_ms__dlrtn_1 _TECHMAP_DLATCH_NN0 (
+    .Q       (Q),
+    .RESET_B (R),
+    .D       (D),
+    .GATE_N  (E)
+  );
+endmodule
+
+// while the SCL also contains the following lathes with complementary outputs,
+// they are commented out, since Yosys lacks primities mapping for complementary outputs
+
+// Delay latch, non-inverted enable, complementary outputs
+//module sky130_fd_sc_ms__dlxbp_1 (
+//    Q   ,
+//    Q_N ,
+//    D   ,
+//    GATE
+//);
+
+// Delay latch, inverted enable, complementary outputs
+//module sky130_fd_sc_ms__dlxbn_1 (
+//    Q     ,
+//    Q_N   ,
+//    D     ,
+//    GATE_N
+//);
+
+// Delay latch, inverted reset, non-inverted enable, complementary outputs
+//module sky130_fd_sc_ms__dlrbp_1 (
+//    Q      ,
+//    Q_N    ,
+//    RESET_B,
+//    D      ,
+//    GATE
+//);
+
+// Delay latch, inverted reset, inverted enable, complementary outputs
+//module sky130_fd_sc_ms__dlrbn_1 (
+//    Q      ,
+//    Q_N    ,
+//    RESET_B,
+//    D      ,
+//    GATE_N
+//);


### PR DESCRIPTION
1. Reordered ports for existing latches (`$_DLATCH_[PN]_`) to match the order in the cell Verilog definition.
2. Added latches with active low reset (`\$_DLATCH_[PN]N0_`).
3. Added cells for latches with complementary outputs, but they are commented out, since Yosys does not support them. This is done to make it explicit that additional lathes exist and that there are specific reasons for not mapping them.

~While testing this code, I noticed Yosys fails to infer latches with reset properly,
so I filled an issue~ https://github.com/YosysHQ/yosys/issues/5910
UPDATE: Yosys support for latches with preset/reset was merged.
This pull request should remain a draft, till the Yosys issue is fixed
and maybe further till the fixed version of Yosys becomes part of `nix-eda` and LibreLane.