### PR TITLE
Reclassify some sky130_ef_io cells from CLASS PAD AREAIO to CLASS PAD SPACER

### DIFF
--- a/sky130/custom/sky130_fd_io/lef/sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um.lef
+++ b/sky130/custom/sky130_fd_io/lef/sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um.lef
@@ -3,7 +3,7 @@ VERSION 5.7 ;
   DIVIDERCHAR "/" ;
   BUSBITCHARS "[]" ;
 MACRO sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um
-  CLASS PAD AREAIO ;
+  CLASS PAD SPACER ;
   FOREIGN sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um ;
   ORIGIN 0.000 0.000 ;
   SIZE 20.000 BY 197.965 ;

--- a/sky130/custom/sky130_fd_io/lef/sky130_ef_io__disconnect_vccd_slice_5um.lef
+++ b/sky130/custom/sky130_fd_io/lef/sky130_ef_io__disconnect_vccd_slice_5um.lef
@@ -3,7 +3,7 @@ VERSION 5.7 ;
   DIVIDERCHAR "/" ;
   BUSBITCHARS "[]" ;
 MACRO sky130_ef_io__disconnect_vccd_slice_5um
-  CLASS PAD AREAIO ;
+  CLASS PAD SPACER ;
   FOREIGN sky130_ef_io__disconnect_vccd_slice_5um ;
   ORIGIN 0.000 0.000 ;
   SIZE 5.000 BY 197.965 ;

--- a/sky130/custom/sky130_fd_io/lef/sky130_ef_io__disconnect_vdda_slice_5um.lef
+++ b/sky130/custom/sky130_fd_io/lef/sky130_ef_io__disconnect_vdda_slice_5um.lef
@@ -3,7 +3,7 @@ VERSION 5.7 ;
   DIVIDERCHAR "/" ;
   BUSBITCHARS "[]" ;
 MACRO sky130_ef_io__disconnect_vdda_slice_5um
-  CLASS PAD AREAIO ;
+  CLASS PAD SPACER ;
   FOREIGN sky130_ef_io__disconnect_vdda_slice_5um ;
   ORIGIN 0.000 0.000 ;
   SIZE 5.000 BY 197.965 ;


### PR DESCRIPTION
Reclassified cells:
  - sky130_ef_io__disconnect_vccd_slice_5um
  - sky130_ef_io__disconnect_vdda_slice_5um
  - sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um

In the Cadence LEF/DEF 5.8 Language Reference, under MACRO CLASS:
- AREAIO for area I/O driver cells that do not have the bump built in as part of the macro (and therefore require routing to a CLASS COVER BUMP macro for a connection to the IC package).

These cells are peripheral IO ring cells, not area-array bump drivers, and sky130's IO library is built around wire-bond pads rather than bumps, so AREAIO does not apply here, and should be reclassified as SPACER.
  
These changes follow the same reclassification already applied to the cell sky130_ef_io__connect_vdda_vddio_and_vssa_vssio_slice_20um in [d815bb3](https://github.com/fossi-foundation/open-pdks/commit/d815bb30c9afdf9e264c276a8a2b533108dea3d0).

These changes were also validated on silicon with SRAM timing analysis chip v2 [STAC](https://github.com/ucb-substrate/sram22)